### PR TITLE
Remove ',' to fix syntax error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,20 +39,20 @@ fetch.Response = ResponseWrapper;
 fetch.Request = self.Request;
 fetch.mockResponse = (body, init) => {
   fetch.mockImplementation(
-    () => Promise.resolve(new ResponseWrapper(body, init)),
+    () => Promise.resolve(new ResponseWrapper(body, init))
   );
 };
 
 fetch.mockResponseOnce = (body, init) => {
   fetch.mockImplementationOnce(
-    () => Promise.resolve(new ResponseWrapper(body, init)),
+    () => Promise.resolve(new ResponseWrapper(body, init))
   );
 };
 
 fetch.mockResponses = (...responses) => {
   responses.forEach(([ body, init ]) => {
     fetch.mockImplementationOnce(
-      () => Promise.resolve(new ResponseWrapper(body, init)),
+      () => Promise.resolve(new ResponseWrapper(body, init))
     );
   })
 };


### PR DESCRIPTION
Those ',' cause a syntax error. Remove them fix it and make the lib work just fine. 😄 