### PR TITLE
Ease testing of error requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,33 +33,35 @@ function ResponseWrapper(body, init) {
   return new ActualResponse(body, init);
 }
 
+function fetchMockImplementation(body, init) {
+    if(init && init.status >= 400) {
+      return Promise.reject(new ResponseWrapper(body, init))
+    }
+    else {
+      return Promise.resolve(new ResponseWrapper(body, init))
+    }
+}
+
 const fetch = jest.fn();
 fetch.Headers = Headers;
 fetch.Response = ResponseWrapper;
 fetch.Request = Request;
 fetch.mockResponse = (body, init) => {
   fetch.mockImplementation(
-    () => {
-      if(init && init.status >= 400) {
-        return Promise.reject(new ResponseWrapper(body, init))
-      }
-      else {
-        return Promise.resolve(new ResponseWrapper(body, init))
-      }
-    }
+    () => fetchMockImplementation(body, init)
   );
 };
 
 fetch.mockResponseOnce = (body, init) => {
   fetch.mockImplementationOnce(
-    () => Promise.resolve(new ResponseWrapper(body, init))
+    () => fetchMockImplementation(body, init)
   );
 };
 
 fetch.mockResponses = (...responses) => {
   responses.forEach(([ body, init ]) => {
     fetch.mockImplementationOnce(
-      () => Promise.resolve(new ResponseWrapper(body, init))
+      () => fetchMockImplementation(body, init)
     );
   })
 };

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,14 @@ fetch.Response = ResponseWrapper;
 fetch.Request = Request;
 fetch.mockResponse = (body, init) => {
   fetch.mockImplementation(
-    () => Promise.resolve(new ResponseWrapper(body, init))
+    () => {
+      if(init && init.status >= 400) {
+        return Promise.reject(new ResponseWrapper(body, init))
+      }
+      else {
+        return Promise.resolve(new ResponseWrapper(body, init))
+      }
+    }
   );
 };
 


### PR DESCRIPTION
Hi there!

First, thanks for your great module, very helpful for most of my test use cases. 

That said, I've found a use case that is not easy to test using the current state of this module. This is when fetch return an error status. Right now, jest-fetch-mock always resolve the Promise even when we mock an error status (> 400)
This pull request try to fix that by rejecting any request that have an init AND a status of 400 or higher.

Now you can do:
```javascript
fetch.mockResponse(JSON.stringify({}), { status: 404, statusText: "404 Not Found" })
```

and it will end in the `.catch(error) {}` block of your tested fetch request

Hope this helps!