### PR TITLE
Return mock function when calling any of the api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ For information on the parameters body and init take, you can look at the MDN do
 
 https://developer.mozilla.org/en-US/docs/Web/API/Response/Response
 
+Each API will return a [Mock Function](http://facebook.github.io/jest/docs/mock-function-api.html#content). You can use methods like `.toHaveBeenCalledWith` to ensure that the mock function was called with specific arguments. For more methods detail, take a look at [this](http://facebook.github.io/jest/docs/expect.html#content).
+
 In the examples below, I am testing my action creators in Redux, but it doesn't have to be used with Redux.
 
 ## Example 1 - Mocking all fetches

--- a/src/index.js
+++ b/src/index.js
@@ -38,20 +38,20 @@ fetch.Headers = Headers;
 fetch.Response = ResponseWrapper;
 fetch.Request = Request;
 fetch.mockResponse = (body, init) => {
-  fetch.mockImplementation(
+  return fetch.mockImplementation(
     () => Promise.resolve(new ResponseWrapper(body, init))
   );
 };
 
 fetch.mockResponseOnce = (body, init) => {
-  fetch.mockImplementationOnce(
+  return fetch.mockImplementationOnce(
     () => Promise.resolve(new ResponseWrapper(body, init))
   );
 };
 
 fetch.mockResponses = (...responses) => {
-  responses.forEach(([ body, init ]) => {
-    fetch.mockImplementationOnce(
+  return responses.map(([ body, init ]) => {
+    return fetch.mockImplementationOnce(
       () => Promise.resolve(new ResponseWrapper(body, init))
     );
   })


### PR DESCRIPTION
This allow us to get the instance information like `.toHaveBeenCalledWith`.
And maybe this is related to https://github.com/jefflau/jest-fetch-mock/issues/7