### PR TITLE
isomorphic-fetch typo fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-require('isomoprhic-fetch');
+require('isomorphic-fetch');
 
 const ActualResponse = Response;
 


### PR DESCRIPTION
Fixed fokin' `isomorphic-fetch` typo :fire: :fire: :fire: :fire: 