### PR TITLE
correct type definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,11 +1,11 @@
-declare interface MockParams {
-  status?: number;
-  statusText?: string;
-  url?: string;
-  headers?: Object;
-}
+declare module "jest-fetch-mock" {
+  interface MockParams {
+    status?: number;
+    statusText?: string;
+    url?: string;
+    headers?: Object;
+  }
 
-declare namespace fetch {
   function mockResponse(body: string, init?: MockParams): void;
   function mockResponseOnce(body: string, init?: MockParams): void;
   function mockResponses(responses: Array<{body: string, init?: MockParams}>): void;


### PR DESCRIPTION
Convert namespace to module. 
Looks like it better supported by newer versions of TS.