### PR TITLE
Fix mockReject types to accept an optional error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-fetch-mock",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@ declare namespace fetch {
   function mockResponseOnce(body: string, init?: MockParams): void;
   function mockResponses(responses: Array<{body: string, init?: MockParams}>): void;
   function resetMocks(): void;
-  function mockReject(): void;
-  function mockRejectOnce(): void;
+  function mockReject(error?: Error): void;
+  function mockRejectOnce(error?: Error): void;
   function resetMocks(): void;
 }


### PR DESCRIPTION
According to the implementation, mockReject accepts an error object.
The types didn't take this into account.