### PR TITLE
make the body optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const Promise = require('promise-polyfill');
 const ActualResponse = Response
 
 function ResponseWrapper(body, init) {
-  if (typeof body.constructor === 'function' && body.constructor.__isFallback) {
+  if (body && typeof body.constructor === 'function' && body.constructor.__isFallback) {
     const response = new ActualResponse(null, init)
     response.body = body
 


### PR DESCRIPTION
Tiny PR to make the `body` parameter optional so that this doesn't error on `null`s, which are allowed according to [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response).