### PR TITLE
#66: Only polyfill promise when it is not present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,11 +2,15 @@
   "name": "jest-fetch-mock",
   "version": "1.6.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -21,12 +25,20 @@
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
     },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ=="
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "promise-polyfill": {
       "version": "7.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 require('isomorphic-fetch')
-const Promise = require('promise-polyfill');
+
+if (!Promise) {
+  Promise = require('promise-polyfill');
+} else if (!Promise.finally) {
+  Promise.finally = require('promise-polyfill').finally;
+}
 
 const ActualResponse = Response
 


### PR DESCRIPTION
Addresses #66.  I've verified that this resolves the regression, but I have not verified that `Promise.finally` works as intended.  It is implemented in terms of Promise primitives, though, so it should work the same on the native Promise as on the polyfilled Promise.