### PR TITLE
Small fetch function types update

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,16 +6,22 @@ declare module "jest-fetch-mock" {
     headers?: Object;
   }
 
-  const fn: {
-    (input?: string | Request, init?: RequestInit): Promise<Response>;
-    mockResponse(body: string, init?: MockParams): void;
-    mockResponseOnce(body: string, init?: MockParams): void;
-    mockResponses(responses: Array<{body: string, init?: MockParams}>): void;
-    resetMocks(): void;
-    mockReject(error?: Error): void;
-    mockRejectOnce(error?: Error): void;
-    resetMocks(): void;
+  interface MockContext {
+    calls: any[][];
+    instances: any[];
   }
 
+  interface Fetch {
+    (input?: string | Request, init?: RequestInit): Promise<Response>;
+    mockResponse(body: string, init?: MockParams): Fetch;
+    mockResponseOnce(body: string, init?: MockParams): Fetch;
+    mockResponses(responses: Array<{body: string, init?: MockParams}>): Fetch;
+    mockReject(error?: Error): Fetch;
+    mockRejectOnce(error?: Error): Fetch;
+    resetMocks(): void;
+    mock: MockContext;
+  }
+
+  const fn: Fetch;
   export = fn;
 }


### PR DESCRIPTION
Small update to address my two issues (mockResponse methods returning mock functions, no access to fetch.mock).

Closes #70 