### PR TITLE
Import jest types rather than duplicating, change mockResponses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/jest": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.0.0.tgz",
+      "integrity": "sha512-hy+8Sdet9JiNEZpJZWRcmT4pBz19H9dKMr/qWD1JJINBpTTts+Vbe8P+nx9vRJUlbVN4GMPAVr1F4Ff3V5U/Kg=="
+    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/jefflau/jest-fetch-mock#readme",
   "dependencies": {
+    "@types/jest": "^23.0.0",
     "isomorphic-fetch": "^2.2.1",
     "promise-polyfill": "^7.1.1"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,6 @@
 declare module "jest-fetch-mock" {
+  import "jest";
+
   interface MockParams {
     status?: number;
     statusText?: string;
@@ -6,16 +8,16 @@ declare module "jest-fetch-mock" {
     headers?: Object;
   }
 
-  const fn: {
+  interface Fetch {
     (input?: string | Request, init?: RequestInit): Promise<Response>;
-    mockResponse(body: string, init?: MockParams): void;
-    mockResponseOnce(body: string, init?: MockParams): void;
-    mockResponses(responses: Array<{body: string, init?: MockParams}>): void;
-    resetMocks(): void;
-    mockReject(error?: Error): void;
-    mockRejectOnce(error?: Error): void;
+    mockResponse(body: string, init?: MockParams): Fetch;
+    mockResponseOnce(body: string, init?: MockParams): Fetch;
+    mockResponses(...responses : Array<[string] | [string, MockParams]>): Fetch;
+    mockReject(error?: Error): Fetch;
+    mockRejectOnce(error?: Error): Fetch;
     resetMocks(): void;
   }
 
+  const fn: Fetch & jest.MockInstance<any>;
   export = fn;
 }


### PR DESCRIPTION
https://github.com/jefflau/jest-fetch-mock/pull/71#pullrequestreview-127277552 brought up a good point re: importing jest's types rather than duplicating them.

https://github.com/jefflau/jest-fetch-mock/issues/70#issuecomment-394534667 noticed that the current `mockResponses` definition doesn't match the current behavior. Was the type preemptively changed to match a planned change? If not, and this is a mistake, this PR would also fix that.