### PR TITLE
Add blob() support. Use node-fetch directly instead of isomorphic-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,51 +9,15 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.0.0.tgz",
       "integrity": "sha512-hy+8Sdet9JiNEZpJZWRcmT4pBz19H9dKMr/qWD1JJINBpTTts+Vbe8P+nx9vRJUlbVN4GMPAVr1F4Ff3V5U/Kg=="
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "promise-polyfill": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.1.tgz",
       "integrity": "sha512-k1ArwERleWt59+JZuPp5Asd4+Eo3R6g4SDWKl8ozLYZE6K5pZULl1e4hlg112OYVgQcJ6IwBlBHP6JkCDUrayA=="
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/jefflau/jest-fetch-mock#readme",
   "dependencies": {
     "@types/jest": "^23.0.0",
-    "isomorphic-fetch": "^2.2.1",
+    "node-fetch": "^2.1.2",
     "promise-polyfill": "^7.1.1"
   },
   "prettier": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,9 @@
-require('isomorphic-fetch')
+const nodeFetch = require('node-fetch');
+
+global.fetch = nodeFetch;
+global.Response = nodeFetch.Response;
+global.Headers = nodeFetch.Headers;
+global.Request = nodeFetch.Request;
 
 if (!Promise) {
   Promise = require('promise-polyfill');


### PR DESCRIPTION
As mentioned on #45 by @coremessage, using `isomorphic-fetch` implies using an old version of `node-fetch` which lacks `blob()`.

As `jest-fetch-mock` is node-only, I think it's better to use `node-fetch` directly.