### PR TITLE
Use cross-fetch to avoid missing "Response.blob()"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
-require('isomorphic-fetch')
+const crossFetch = require("cross-fetch");
+global.fetch = crossFetch;
+global.Response = crossFetch.Response;
+global.Headers = crossFetch.Headers;
+global.Request = crossFetch.Request;
 
 if (!Promise) {
   Promise = require('promise-polyfill');


### PR DESCRIPTION
Fixes #45 
Problem: Isomorphic-fetch hasn't been updated in ages and hence is missing things like the definition of `Response.blob()`.

Solution:
* Cross-fetch seems like a good alternative that's equivalent but updated.
* I believe based on my testing that using just node-fetch directly would break using non-absolute URLs.
* Cross-fetch delegates to node-fetch when appropriate, so hopefully it'll work for @drewler,  so long as the import is set up correctly.