### PR TITLE
Move @typings/jest to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "@types/jest": {
       "version": "23.0.0",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.0.0.tgz",
-      "integrity": "sha512-hy+8Sdet9JiNEZpJZWRcmT4pBz19H9dKMr/qWD1JJINBpTTts+Vbe8P+nx9vRJUlbVN4GMPAVr1F4Ff3V5U/Kg=="
+      "integrity": "sha512-hy+8Sdet9JiNEZpJZWRcmT4pBz19H9dKMr/qWD1JJINBpTTts+Vbe8P+nx9vRJUlbVN4GMPAVr1F4Ff3V5U/Kg==",
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
   },
   "homepage": "https://github.com/jefflau/jest-fetch-mock#readme",
   "dependencies": {
-    "@types/jest": "^23.0.0",
     "isomorphic-fetch": "^2.2.1",
     "promise-polyfill": "^7.1.1"
+  },
+  "devDependencies": {
+    "@types/jest": "^23.0.0"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Since jest functions are global, their typing tends to conflict with other global values in
global space. This commit moves jest typings to devDependencies, where they won't be
included for projects that require jest-fetch-mock.

This is very similar to a protractor issue, references here-
https://github.com/angular/protractor/issues/3792
https://github.com/angular/protractor/pull/3795