### PR TITLE
Adds mockMatchingResponses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ const matchedResponses = (responses) => {
   responses.forEach(([pattern, bodyOrFunction, init]) => {
     responder.set(pattern, () => respond(bodyOrFunction, init))
   })
-  // responder is now be a Map of /pattern/: fn() pairs
+  // responder is now a Map of /pattern/: fn() pairs
   return responder
 }
 

--- a/tests/api.js
+++ b/tests/api.js
@@ -22,6 +22,10 @@ export function APIRequest2(who) {
   }
 }
 
+export function customRequest(uri) {
+  return fetch(uri).then(res => res.json())
+}
+
 export function request() {
   return fetch('https://randomuser.me/api', {})
     .then(response => {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,4 @@
-import { APIRequest, APIRequest2, request } from './api'
+import { APIRequest, APIRequest2, customRequest, request } from './api'
 
 describe('testing mockResponse and alias once', () => {
   beforeEach(() => {
@@ -94,6 +94,34 @@ describe('testing mockResponses', () => {
       'https://facebook.com/someOtherResource'
     )
     expect(fetch.mock.calls[1][0]).toEqual('https://facebook.com')
+  })
+})
+
+describe('testing mockMatchingResponses', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+    fetch.mockMatchingResponses(
+      [/apple/, JSON.stringify({ name: 'apple' })],
+      [/twitter/, JSON.stringify({ name: 'twitter' })]
+    )
+  })
+
+  it('responds with bodyOrFunction that matches fetch uri (1 of 2)', async () => {
+    const appleResponse = await customRequest('http://apple.com')
+    expect(appleResponse).toEqual({ name: 'apple' })
+    expect(fetch.mock.calls.length).toEqual(1)
+  })
+
+  it('responds with bodyOrFunction that matches fetch uri (2 of 2)', async () => {
+    const twitterResponse = await customRequest('mobile.twitter.com')
+    expect(twitterResponse).toEqual({ name: 'twitter' })
+    expect(fetch.mock.calls.length).toEqual(1)
+  })
+
+  it('returns a default response if there is no match on uri', async () => {
+    const otherResponse = await customRequest('this.wont.work.com')
+    expect(otherResponse).toEqual('')
+    expect(fetch.mock.calls.length).toEqual(1)
   })
 })
 
@@ -238,3 +266,4 @@ describe('request', () => {
     }
   })
 })
+


### PR DESCRIPTION
Proposal to add `mockMatchingResponses` function that will allow similar functionality to `mockResponses`, but with the added specification of patterns to match on the fetch URI.

Inspired by my own needs with `jest-mock-fetch` at work, as well at #95 