### PR TITLE
fix(README): correct mock slow servers code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,8 +529,7 @@ import { request } from './api'
 describe('testing timeouts', () => {
   it('resolves with function and timeout', async () => {
     fetch.mockResponseOnce(
-      () => new Promise(resolve => setTimeout(() => resolve({ body: 'ok' }))),
-      100
+      () => new Promise(resolve => setTimeout(() => resolve({ body: 'ok' }), 100))
     )
     try {
       const response = await request()


### PR DESCRIPTION
Fix mock slow servers code example on README - Move timeout parameter `100` into `setTimeout` function.