### PR TITLE
Include @types/node in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ Add the setupFile to your jest config in `package.json`:
 ### TypeScript guide
 
 If you are using TypeScript, then you can follow the instructions below instead.
-
 ```
-$ npm install --save-dev jest-fetch-mock
+$ npm install --save-dev jest-fetch-mock @types/node
 ```
 
 Create a `setupJest.ts` file to setup the mock :


### PR DESCRIPTION
Include the Node type definitions in the npm install command for jest-fetch-mock in the TypeScript section. Without these TypeScript does not compile the Jest setup file.