### PR TITLE
Add tsconfig.json include/files property warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Add the setupFile to your jest config in `package.json`:
 }
 ```
 
+> Note: If the `"files"` or `"include"` properties are set in the `tsconfig.json` file, then the `setupJest.ts` file must be included. Otherwise, the TypeScript compiler will fail to find `fetchMock`.
+
 With this done, you'll have `fetch` and `fetchMock` available on the global scope. Fetch will be used as usual by your code and you'll use `fetchMock` in your tests.
 
 ### Using with Create-React-App


### PR DESCRIPTION
If the `"files"` or `"include"` properties are set in the `tsconfig.json` file, then the `setupJest.ts` file must be included. Otherwise, the TypeScript compiler will fail to find `fetchMock`.

Example in `tsconfig.json`:
```
  "include": [
    "src/**/*",
    "test/**/*"
  ],
```

For fun: It'll work _sometimes_. I have a 100% reliable example where the existence of a newline at the top of the test file causes it to pass. Removing the newline causes it to fail.

Example failure:
```
$ jest
 FAIL  test/hello.test.ts
  ● Test suite failed to run

    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    test/hello.test.ts:48:5 - error TS2304: Cannot find name 'fetchMock'.

    48     fetchMock.mockResponseOnce('Hello');
           ~~~~~~~~~
    test/hello.test.ts:67:12 - error TS2304: Cannot find name 'fetchMock'.

    67     expect(fetchMock).toBeCalledTimes(1);
                  ~~~~~~~~~

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.451s
Ran all test suites.
```