### PR TITLE
mock fetches to obey abort signals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ if (!Promise) {
   Promise.finally = require('promise-polyfill').finally
 }
 
-const abort = () => { throw new Error('Aborted') }
+const abort = () => { throw new DOMException('The operation was aborted. ', 'AbortError'); }
 
 const ActualResponse = Response
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ if (!Promise) {
   Promise.finally = require('promise-polyfill').finally
 }
 
+const abort = () => { throw new Error('Aborted') }
+
 const ActualResponse = Response
 
 function ResponseWrapper(body, init) {
@@ -33,6 +35,10 @@ function ResponseWrapper(body, init) {
     return response
   }
 
+  if(init && init.signal) {
+    init.signal.aborted ? abort() : init.signal.addEventListener('abort',abort);
+  }
+
   return new ActualResponse(body, init)
 }
 
@@ -51,6 +57,8 @@ fetch.Headers = Headers
 fetch.Response = ResponseWrapper
 fetch.Request = Request
 fetch.mockResponse = (bodyOrFunction, init) => fetch.mockImplementation(normalizeResponse(bodyOrFunction, init))
+
+fetch.mockAbort = () => fetch.mockImplementation(normalizeError(abort));
 
 fetch.mockReject = errorOrFunction => fetch.mockImplementation(normalizeError(errorOrFunction))
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -97,6 +97,44 @@ describe('testing mockResponses', () => {
   })
 })
 
+describe('Mocking aborts',() => {
+
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('throws an AbortError',() => {
+    fetch.mockAbort();
+    expect(() => fetch('/')).toThrow();
+  })
+
+  it('throws when passed an aborted abort signal',() => {
+    const c = new AbortController();
+    c.abort();
+    fetch.mockResponse('',{signal:c.signal});
+    expect(() => fetch('/')).toThrow();
+  })
+
+  it('throws when aborted before resolved',async () => {
+    const c = new AbortController();
+    fetch.mockResponse(() => {
+      return new Promise(res => {
+        setTimeout(() => {
+          res({
+            body:'some body',
+            init:{signal:c.signal}
+          })
+        },100);
+      })
+    })
+
+    const res = fetch('/');
+    setTimeout(() => c.abort(),50);
+    await expect(res).rejects.toBeTruthy();
+  })
+
+})
+
 describe('Mocking rejects', () => {
   beforeEach(() => {
     fetch.resetMocks()


### PR DESCRIPTION
Just a thought, I like jest-fetch-mock but my tests frequently include 

`expect(fetch.mock.calls[0][1].signal.aborted).toBeTruthy();`

when I'd much rather do an 

`expect(...).rejects.toThrow()`