### PR TITLE
feat: conditional mocking and other enhancements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+types/test.ts

--- a/README.md
+++ b/README.md
@@ -556,9 +556,9 @@ Calling `fetch.resetMocks()` will return to the default behavior of mocking all 
     (i.e. "only mock 'fetch' if the request is for the given URL otherwise, use the real fetch implementation").
 - `fetch.neverMock(urlOrPredicate):fetch` - causes all requests to be mocked unless they match the given string/RegExp/predicate
     (i.e. "never mock 'fetch' if the request is for the given URL, otherwise mock the request")
-- `fetch.onlyMockOnce(urlOrPredicate):fetch` - causes the next request to be passed through unless it matches the given string/RegExp/predicate 
+- `fetch.onlyMockOnce(urlOrPredicate):fetch` - causes the next request to mocked if it matches the given string/RegExp/predicate
     (i.e. "only mock 'fetch' if the next request is for the given URL otherwise, use the default behavior").
-- `fetch.neverMockOnce(urlOrPredicate):fetch` - causes all requests to be mocked unless it matches the given string/RegExp/predicate
+- `fetch.neverMockOnce(urlOrPredicate):fetch` - causes the next request to be passed through if it matches the given string/RegExp/predicate
     (i.e. "never mock 'fetch' if the next request is for the given URL, otherwise use the default behavior") 
 - `fetch.isMocking(input, init):boolean` - test utility function to see if the given url/request would be mocked
 ```js

--- a/README.md
+++ b/README.md
@@ -570,25 +570,29 @@ Calling `fetch.resetMocks()` will return to the default behavior of mocking all 
 ```js
 
 describe('conditional mocking', () => {
-  const testUrl = 'https://randomuser.me/api'
-  let nodeFetchSpy
+  const realResponse = 'REAL FETCH RESPONSE'
+  const mockedDefaultResponse = 'MOCKED DEFAULT RESPONSE'
+  const testUrl = defaultRequestUri
+  let crossFetchSpy
   beforeEach(() => {
     fetch.resetMocks()
-    fetch.mockResponse('foo')
-    nodeFetchSpy = jest
+    fetch.mockResponse(mockedDefaultResponse)
+    crossFetchSpy = jest
       .spyOn(require('cross-fetch'), 'fetch')
-      .mockImplementation(async () => Promise.resolve(new Response('bar')))
+      .mockImplementation(async () =>
+        Promise.resolve(new Response(realResponse))
+      )
   })
 
   afterEach(() => {
-    nodeFetchSpy.mockRestore()
+    crossFetchSpy.mockRestore()
   })
 
-  const expectMocked = async () => {
-    return expect(request()).resolves.toEqual('foo')
+  const expectMocked = async (uri, response = mockedDefaultResponse) => {
+    return expect(request(uri)).resolves.toEqual(response)
   }
-  const expectUnmocked = async () => {
-    return expect(request()).resolves.toEqual('bar')
+  const expectUnmocked = async uri => {
+    return expect(request(uri)).resolves.toEqual(realResponse)
   }
 
   describe('onlyMockIf', () => {
@@ -735,29 +739,187 @@ describe('conditional mocking', () => {
     })
   })
 
-  describe("dont/do mock", () => {
-    test("dontMock", async () => {
+  describe('dont/do mock', () => {
+    test('dontMock', async () => {
       fetch.dontMock()
       await expectUnmocked()
       await expectUnmocked()
     })
-    test("dontMockOnce", async () => {
+    test('dontMockOnce', async () => {
       fetch.dontMockOnce()
       await expectUnmocked()
       await expectMocked()
     })
-    test("doMock", async () => {
+    test('doMock', async () => {
       fetch.dontMock()
       fetch.doMock()
       await expectMocked()
       await expectMocked()
     })
-    test("doMockOnce", async () => {
+    test('doMockOnce', async () => {
       fetch.dontMock()
       fetch.doMockOnce()
       await expectMocked()
       await expectUnmocked()
     })
   })
+
+  describe('complex example', () => {
+    const alternativeUrl = 'http://bar'
+    const alternativeBody = 'ALTERNATIVE RESPONSE'
+    beforeEach(() => {
+      fetch
+        // .mockResponse(mockedDefaultResponse) // set above - here for clarity
+        .once('1') // 1
+        .once('2') // 2
+        .once(async uri => (uri === alternativeUrl ? alternativeBody : '3')) // 3
+        .once('4') // 4
+        .once('5') // 5
+        .once(async uri =>
+          uri === alternativeUrl ? alternativeBody : mockedDefaultResponse
+        ) // 6
+    })
+
+    describe('default (`doMock`)', () => {
+      beforeEach(() => {
+        fetch
+          // .doMock()    // the default - here for clarify
+          .neverMockOnceIf(alternativeUrl)
+          .onlyMockOnceIf(alternativeUrl)
+          .doMockOnce()
+          .dontMockOnce()
+      })
+
+      test('defaultRequestUri', async () => {
+        await expectMocked(defaultRequestUri, '1') // 1
+        await expectUnmocked(defaultRequestUri) // 2
+        await expectMocked(defaultRequestUri, '3') // 3
+        await expectUnmocked(defaultRequestUri) // 4
+        // after .once('..')
+        await expectMocked(defaultRequestUri, '5') // 5
+        await expectMocked(defaultRequestUri, mockedDefaultResponse) // 6
+        // default 'isMocked' (not 'Once')
+        await expectMocked(defaultRequestUri, mockedDefaultResponse) // 7
+      })
+
+      test('alternativeUrl', async () => {
+        await expectUnmocked(alternativeUrl) // 1
+        await expectMocked(alternativeUrl, '2') // 2
+        await expectMocked(alternativeUrl, alternativeBody) // 3
+        await expectUnmocked(alternativeUrl) // 4
+        // after .once('..')
+        await expectMocked(alternativeUrl, '5') // 5
+        await expectMocked(alternativeUrl, alternativeBody) // 6
+        // default 'isMocked' (not 'Once')
+        await expectMocked(alternativeUrl, mockedDefaultResponse) // 7
+      })
+    })
+
+    describe('dontMock', () => {
+      beforeEach(() => {
+        fetch
+          .dontMock()
+          .neverMockOnceIf(alternativeUrl)
+          .onlyMockOnceIf(alternativeUrl)
+          .doMockOnce()
+          .dontMockOnce()
+      })
+
+      test('defaultRequestUri', async () => {
+        await expectMocked(defaultRequestUri, '1') // 1
+        await expectUnmocked(defaultRequestUri) // 2
+        await expectMocked(defaultRequestUri, '3') // 3
+        await expectUnmocked(defaultRequestUri) // 4
+        // after .once('..')
+        await expectUnmocked(defaultRequestUri) // 5
+        await expectUnmocked(defaultRequestUri) // 6
+        // default 'isMocked' (not 'Once')
+        await expectUnmocked(defaultRequestUri) // 7
+      })
+
+      test('alternativeUrl', async () => {
+        await expectUnmocked(alternativeUrl) // 1
+        await expectMocked(alternativeUrl, '2') // 2
+        await expectMocked(alternativeUrl, alternativeBody) // 3
+        await expectUnmocked(alternativeUrl) // 4
+        // after .once('..')
+        await expectUnmocked(alternativeUrl) // 5
+        await expectUnmocked(alternativeUrl) // 6
+        // default 'isMocked' (not 'Once')
+        await expectUnmocked(alternativeUrl) // 7
+      })
+    })
+
+    describe('onlyMockIf(alternativeUrl)', () => {
+      beforeEach(() => {
+        fetch
+          .onlyMockIf(alternativeUrl)
+          .neverMockOnceIf(alternativeUrl)
+          .onlyMockOnceIf(alternativeUrl)
+          .doMockOnce()
+          .dontMockOnce()
+      })
+
+      test('defaultRequestUri', async () => {
+        await expectMocked(defaultRequestUri, '1') // 1
+        await expectUnmocked(defaultRequestUri) // 2
+        await expectMocked(defaultRequestUri, '3') // 3
+        await expectUnmocked(defaultRequestUri) // 4
+        // after .once('..')
+        await expectUnmocked(defaultRequestUri) // 5
+        await expectUnmocked(defaultRequestUri) // 6
+        // default 'isMocked' (not 'Once')
+        await expectUnmocked(defaultRequestUri) // 7
+      })
+
+      test('alternativeUrl', async () => {
+        await expectUnmocked(alternativeUrl) // 1
+        await expectMocked(alternativeUrl, '2') // 2
+        await expectMocked(alternativeUrl, alternativeBody) // 3
+        await expectUnmocked(alternativeUrl) // 4
+        // after .once('..')
+        await expectMocked(alternativeUrl, '5') // 5
+        await expectMocked(alternativeUrl, alternativeBody) // 6
+        // default 'isMocked' (not 'Once')
+        await expectMocked(alternativeUrl, mockedDefaultResponse) // 7
+      })
+    })
+
+    describe('neverMockIf(alternativeUrl)', () => {
+      beforeEach(() => {
+        fetch
+          .neverMockIf(alternativeUrl)
+          .neverMockOnceIf(alternativeUrl)
+          .onlyMockOnceIf(alternativeUrl)
+          .doMockOnce()
+          .dontMockOnce()
+      })
+
+      test('defaultRequestUri', async () => {
+        await expectMocked(defaultRequestUri, '1') // 1
+        await expectUnmocked(defaultRequestUri) // 2
+        await expectMocked(defaultRequestUri, '3') // 3
+        await expectUnmocked(defaultRequestUri) // 4
+        // after .once('..')
+        await expectMocked(defaultRequestUri, '5') // 5
+        await expectMocked(defaultRequestUri, mockedDefaultResponse) // 6
+        // default 'isMocked' (not 'Once')
+        await expectMocked(defaultRequestUri, mockedDefaultResponse) // 7
+      })
+
+      test('alternativeUrl', async () => {
+        await expectUnmocked(alternativeUrl) // 1
+        await expectMocked(alternativeUrl, '2') // 2
+        await expectMocked(alternativeUrl, alternativeBody) // 3
+        await expectUnmocked(alternativeUrl) // 4
+        // after .once('..')
+        await expectUnmocked(alternativeUrl) // 5
+        await expectUnmocked(alternativeUrl) // 6
+        // default 'isMocked' (not 'Once')
+        await expectUnmocked(alternativeUrl) // 7
+      })
+    })
+  })
 })
+
 ```

--- a/package.json
+++ b/package.json
@@ -36,13 +36,25 @@
     "babel-preset-env": "^1.7.0",
     "dtslint": "^0.3.0",
     "jest": "^23.5.0",
+    "prettier": "^1.18.2",
     "regenerator-runtime": "^0.12.1",
     "typescript": "^3.2.1"
   },
   "prettier": {
     "semi": false,
     "editor.formatOnSave": true,
-    "singleQuote": true
+    "singleQuote": true,
+    "overrides": [
+      {
+        "files": "**/*.ts",
+        "options": {
+          "semi": true,
+          "tabWidth": 4,
+          "singleQuote": false,
+          "printWidth": 120
+        }
+      }
+    ]
   },
   "jest": {
     "automock": false,

--- a/src/index.js
+++ b/src/index.js
@@ -54,11 +54,13 @@ function requestMatches(urlOrPredicate) {
   if (typeof urlOrPredicate === 'function') {
     return urlOrPredicate
   }
+  const predicate =
+    urlOrPredicate instanceof RegExp
+      ? input => urlOrPredicate.exec(input) !== null
+      : input => input === urlOrPredicate
   return input => {
     const requestUrl = typeof input === 'object' ? input.url : input
-    return urlOrPredicate instanceof RegExp
-      ? urlOrPredicate.exec(requestUrl) !== null
-      : urlOrPredicate === requestUrl
+    return predicate(requestUrl)
   }
 }
 
@@ -104,7 +106,8 @@ const mockResponseOnce = (bodyOrFunction, init) =>
 
 fetch.mockResponseOnce = mockResponseOnce
 
-fetch.once = mockResponseOnce
+fetch.once = (bodyOrFunction, init) =>
+  mockResponseOnce(bodyOrFunction, init).doMockOnce()
 
 fetch.mockRejectOnce = errorOrFunction =>
   fetch.mockImplementationOnce(normalizeError(errorOrFunction))

--- a/src/index.js
+++ b/src/index.js
@@ -118,23 +118,43 @@ fetch.mockResponses = (...responses) => {
 
 fetch.isMocking = isMocking
 
-fetch.onlyMock = url => {
-  isMocking.mockImplementation(requestMatches(url))
+fetch.onlyMockIf = urlOrPredicate => {
+  isMocking.mockImplementation(requestMatches(urlOrPredicate))
   return fetch
 }
 
-fetch.neverMock = url => {
-  isMocking.mockImplementation(requestNotMatches(url))
+fetch.neverMockIf = urlOrPredicate => {
+  isMocking.mockImplementation(requestNotMatches(urlOrPredicate))
   return fetch
 }
 
-fetch.onlyMockOnce = url => {
-  isMocking.mockImplementationOnce(requestMatches(url))
+fetch.onlyMockOnceIf = urlOrPredicate => {
+  isMocking.mockImplementationOnce(requestMatches(urlOrPredicate))
   return fetch
 }
 
-fetch.neverMockOnce = url => {
-  isMocking.mockImplementationOnce(requestNotMatches(url))
+fetch.neverMockOnceIf = urlOrPredicate => {
+  isMocking.mockImplementationOnce(requestNotMatches(urlOrPredicate))
+  return fetch
+}
+
+fetch.dontMock = () => {
+  isMocking.mockImplementation(() => false)
+  return fetch
+}
+
+fetch.dontMockOnce = () => {
+  isMocking.mockImplementationOnce(() => false)
+  return fetch
+}
+
+fetch.doMock = () => {
+  isMocking.mockImplementation(() => true)
+  return fetch
+}
+
+fetch.doMockOnce = () => {
+  isMocking.mockImplementationOnce(() => true)
   return fetch
 }
 
@@ -144,7 +164,7 @@ fetch.resetMocks = () => {
 
   // reset to default implementation with each reset
   fetch.mockImplementation(normalizeResponse(''))
-  isMocking.mockImplementation(() => true)
+  fetch.doMock()
   fetch.isMocking = isMocking
 }
 

--- a/tests/api.js
+++ b/tests/api.js
@@ -22,8 +22,10 @@ export function APIRequest2(who) {
   }
 }
 
-export function request() {
-  return fetch('https://randomuser.me/api', {})
+export const defaultRequestUri = 'https://randomuser.me/api'
+
+export function request(uri = defaultRequestUri) {
+  return fetch(uri, {})
     .then(response => {
       const contentType = response.headers.get('content-type')
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -218,15 +218,20 @@ describe('request', () => {
   })
 
   it('resolves with function and timeout', async () => {
+    jest.useFakeTimers()
     fetch.mockResponseOnce(
-      () => new Promise(resolve => setTimeout(() => resolve({ body: 'ok' }))),
-      100
+      () =>
+        new Promise(resolve => setTimeout(() => resolve({ body: 'ok' }), 5000))
     )
     try {
-      const response = await request()
+      const req = request()
+      jest.runAllTimers()
+      const response = await req
       expect(response).toEqual('ok')
     } catch (e) {
       throw e
+    } finally {
+      jest.useRealTimers()
     }
   })
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -347,150 +347,177 @@ describe('conditional mocking', () => {
     return expect(request()).resolves.toEqual('bar')
   }
 
-  describe('onlyMock', () => {
+  describe('onlyMockIf', () => {
     it("doesn't mock normally", async () => {
-      fetch.onlyMock('http://foo')
+      fetch.onlyMockIf('http://foo')
       await expectUnmocked()
       await expectUnmocked()
     })
     it('mocks when matches string', async () => {
-      fetch.onlyMock(testUrl)
+      fetch.onlyMockIf(testUrl)
       await expectMocked()
       await expectMocked()
     })
     it('mocks when matches regex', async () => {
-      fetch.onlyMock(new RegExp(testUrl))
+      fetch.onlyMockIf(new RegExp(testUrl))
       await expectMocked()
       await expectMocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.onlyMock(input => input === testUrl)
+      fetch.onlyMockIf(input => input === testUrl)
       await expectMocked()
       await expectMocked()
     })
   })
 
-  describe('neverMock', () => {
+  describe('neverMockIf', () => {
     it('mocks normally', async () => {
-      fetch.neverMock('http://foo')
+      fetch.neverMockIf('http://foo')
       await expectMocked()
       await expectMocked()
     })
     it('doesnt mock when matches string', async () => {
-      fetch.neverMock(testUrl)
+      fetch.neverMockIf(testUrl)
       await expectUnmocked()
       await expectUnmocked()
     })
     it('doesnt mock when matches regex', async () => {
-      fetch.neverMock(new RegExp(testUrl))
+      fetch.neverMockIf(new RegExp(testUrl))
       await expectUnmocked()
       await expectUnmocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.neverMock(input => input === testUrl)
+      fetch.neverMockIf(input => input === testUrl)
       await expectUnmocked()
       await expectUnmocked()
     })
   })
 
-  describe('onlyMockOnce (default mocked)', () => {
+  describe('onlyMockOnceIf (default mocked)', () => {
     it("doesn't mock normally", async () => {
-      fetch.onlyMockOnce('http://foo')
+      fetch.onlyMockOnceIf('http://foo')
       await expectUnmocked()
       await expectMocked()
     })
     it('mocks when matches string', async () => {
-      fetch.onlyMockOnce(testUrl)
+      fetch.onlyMockOnceIf(testUrl)
       await expectMocked()
       await expectMocked()
     })
     it('mocks when matches regex', async () => {
-      fetch.onlyMockOnce(new RegExp(testUrl))
+      fetch.onlyMockOnceIf(new RegExp(testUrl))
       await expectMocked()
       await expectMocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.onlyMockOnce(input => input === testUrl)
+      fetch.onlyMockOnceIf(input => input === testUrl)
       await expectMocked()
       await expectMocked()
     })
   })
 
-  describe('neverMockOnce (default mocked)', () => {
+  describe('neverMockOnceIf (default mocked)', () => {
     it('mocks normally', async () => {
-      fetch.neverMockOnce('http://foo')
+      fetch.neverMockOnceIf('http://foo')
       await expectMocked()
       await expectMocked()
     })
     it('doesnt mock when matches string', async () => {
-      fetch.neverMockOnce(testUrl)
+      fetch.neverMockOnceIf(testUrl)
       await expectUnmocked()
       await expectMocked()
     })
     it('doesnt mock when matches regex', async () => {
-      fetch.neverMockOnce(new RegExp(testUrl))
+      fetch.neverMockOnceIf(new RegExp(testUrl))
       await expectUnmocked()
       await expectMocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.neverMockOnce(input => input === testUrl)
+      fetch.neverMockOnceIf(input => input === testUrl)
       await expectUnmocked()
       await expectMocked()
     })
   })
 
-  describe('onlyMockOnce (default unmocked)', () => {
+  describe('onlyMockOnceIf (default unmocked)', () => {
     beforeEach(() => {
-      fetch.onlyMock('_unknown_')
+      fetch.dontMock()
     })
     it("doesn't mock normally", async () => {
-      fetch.onlyMockOnce('http://foo')
+      fetch.onlyMockOnceIf('http://foo')
       await expectUnmocked()
       await expectUnmocked()
     })
     it('mocks when matches string', async () => {
-      fetch.onlyMockOnce(testUrl)
+      fetch.onlyMockOnceIf(testUrl)
       await expectMocked()
       await expectUnmocked()
     })
     it('mocks when matches regex', async () => {
-      fetch.onlyMockOnce(new RegExp(testUrl))
+      fetch.onlyMockOnceIf(new RegExp(testUrl))
       await expectMocked()
       await expectUnmocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.onlyMockOnce(input => input === testUrl)
+      fetch.onlyMockOnceIf(input => input === testUrl)
       await expectMocked()
       await expectUnmocked()
     })
   })
 
-  describe('neverMockOnce (default unmocked)', () => {
+  describe('neverMockOnceIf (default unmocked)', () => {
     beforeEach(() => {
-      fetch.onlyMock('_unknown_')
+      fetch.dontMock()
     })
     it('mocks normally', async () => {
-      fetch.neverMockOnce('http://foo')
+      fetch.neverMockOnceIf('http://foo')
       await expectMocked()
       await expectUnmocked()
     })
     it('doesnt mock when matches string', async () => {
-      fetch.neverMockOnce(testUrl)
+      fetch.neverMockOnceIf(testUrl)
       await expectUnmocked()
       await expectUnmocked()
     })
     it('doesnt mock when matches regex', async () => {
-      fetch.neverMockOnce(new RegExp(testUrl))
+      fetch.neverMockOnceIf(new RegExp(testUrl))
       await expectUnmocked()
       await expectUnmocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.neverMockOnce(input => input === testUrl)
+      fetch.neverMockOnceIf(input => input === testUrl)
       await expectUnmocked()
+      await expectUnmocked()
+    })
+  })
+
+  describe("dont/do mock", () => {
+    test("dontMock", async () => {
+      fetch.dontMock()
+      await expectUnmocked()
+      await expectUnmocked()
+    })
+    test("dontMockOnce", async () => {
+      fetch.dontMockOnce()
+      await expectUnmocked()
+      await expectMocked()
+    })
+    test("doMock", async () => {
+      fetch.dontMock()
+      fetch.doMock()
+      await expectMocked()
+      await expectMocked()
+    })
+    test("doMockOnce", async () => {
+      fetch.dontMock()
+      fetch.doMockOnce()
+      await expectMocked()
       await expectUnmocked()
     })
   })
 })
+
+
 
 it('enable/disable', () => {
   const jestFetchMock = require('jest-fetch-mock')

--- a/tests/test.js
+++ b/tests/test.js
@@ -351,6 +351,22 @@ describe('conditional mocking', () => {
     return expect(request(uri)).resolves.toEqual(realResponse)
   }
 
+  describe('once', () => {
+    it('default', async () => {
+      const otherResponse = 'other response'
+      fetch.once(otherResponse)
+      await expectMocked(defaultRequestUri, otherResponse)
+      await expectMocked()
+    })
+    it('dont mock then once', async () => {
+      const otherResponse = 'other response'
+      fetch.dontMock()
+      fetch.once(otherResponse)
+      await expectMocked(defaultRequestUri, otherResponse)
+      await expectUnmocked()
+    })
+  })
+
   describe('onlyMockIf', () => {
     it("doesn't mock normally", async () => {
       fetch.onlyMockIf('http://foo')
@@ -526,12 +542,14 @@ describe('conditional mocking', () => {
     beforeEach(() => {
       fetch
         // .mockResponse(mockedDefaultResponse) // set above - here for clarity
-        .once('1') // 1
-        .once('2') // 2
-        .once(async uri => (uri === alternativeUrl ? alternativeBody : '3')) // 3
-        .once('4') // 4
-        .once('5') // 5
-        .once(async uri =>
+        .mockResponseOnce('1') // 1
+        .mockResponseOnce('2') // 2
+        .mockResponseOnce(async uri =>
+          uri === alternativeUrl ? alternativeBody : '3'
+        ) // 3
+        .mockResponseOnce('4') // 4
+        .mockResponseOnce('5') // 5
+        .mockResponseOnce(async uri =>
           uri === alternativeUrl ? alternativeBody : mockedDefaultResponse
         ) // 6
     })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,10 +28,14 @@ export interface FetchMock
     mockRejectOnce(error?: ErrorOrFunction): FetchMock;
 
     isMocking(input: string | Request): boolean;
-    neverMock(urlOrPredicate: UrlOrPredicate): FetchMock;
-    neverMockOnce(urlOrPredicate: UrlOrPredicate): FetchMock;
-    onlyMock(urlOrPredicate: UrlOrPredicate): FetchMock;
-    onlyMockOnce(urlOrPredicate: UrlOrPredicate): FetchMock;
+    dontMock(): FetchMock;
+    dontMockOnce(): FetchMock;
+    doMock(): FetchMock;
+    doMockOnce(): FetchMock;
+    neverMockIf(urlOrPredicate: UrlOrPredicate): FetchMock;
+    neverMockOnceIf(urlOrPredicate: UrlOrPredicate): FetchMock;
+    onlyMockIf(urlOrPredicate: UrlOrPredicate): FetchMock;
+    onlyMockOnceIf(urlOrPredicate: UrlOrPredicate): FetchMock;
 
     resetMocks(): void;
     enableMocks(): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,10 +22,19 @@ export interface FetchMock extends jest.MockInstance<any, any[]> {
     mockResponse(body: BodyOrFunction, init?: MockParams): FetchMock;
     mockResponseOnce(body: BodyOrFunction, init?: MockParams): FetchMock;
     once(body: BodyOrFunction, init?: MockParams): FetchMock;
-    mockResponses(...responses: Array<(BodyOrFunction | [BodyOrFunction, MockParams])>): FetchMock;
+    mockResponses(...responses: Array<BodyOrFunction | [BodyOrFunction, MockParams]>): FetchMock;
     mockReject(error?: ErrorOrFunction): FetchMock;
     mockRejectOnce(error?: ErrorOrFunction): FetchMock;
+
+    isMocking(input: string | Request): boolean;
+    neverMock(urlOrPredicate: UrlOrPredicate): FetchMock;
+    neverMockOnce(urlOrPredicate: UrlOrPredicate): FetchMock;
+    onlyMock(urlOrPredicate: UrlOrPredicate): FetchMock;
+    onlyMockOnce(urlOrPredicate: UrlOrPredicate): FetchMock;
+
     resetMocks(): void;
+    enableMocks(): void;
+    disableMocks(): void;
 }
 
 // reference: https://github.github.io/fetch/#Response
@@ -38,9 +47,14 @@ export interface MockParams {
 
 export interface MockResponseInit extends MockParams {
     body?: string;
+    init?: MockParams;
 }
 
 export type BodyOrFunction = string | MockResponseInitFunction;
-export type ErrorOrFunction = Error | MockResponseInitFunction;
+export type ErrorOrFunction = Error | ((...args: any[]) => Promise<any>);
+export type UrlOrPredicate = string | RegExp | ((input: string | Request, init?: RequestInit) => boolean);
 
-export type MockResponseInitFunction = () => Promise<MockResponseInit>;
+export type MockResponseInitFunction = (
+    input?: string | Request,
+    init?: RequestInit
+) => Promise<MockResponseInit | string>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,7 +42,6 @@ export interface FetchMock
     disableMocks(): void;
 }
 
-// reference: https://github.github.io/fetch/#Response
 export interface MockParams {
     status?: number;
     statusText?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ export interface GlobalWithFetchMock extends Global {
 }
 
 export interface FetchMock
-    extends jest.MockInstance<Promise<Response>, [(string | Request | undefined)?, (RequestInit | undefined)?]> {
+    extends jest.MockInstance<Promise<Response>, [(string | Request | undefined), (RequestInit | undefined)]> {
     (input?: string | Request, init?: RequestInit): Promise<Response>;
 
     mockResponse(body: BodyOrFunction, init?: MockParams): FetchMock;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,7 +16,8 @@ export interface GlobalWithFetchMock extends Global {
     fetch: FetchMock;
 }
 
-export interface FetchMock extends jest.MockInstance<any, any[]> {
+export interface FetchMock
+    extends jest.MockInstance<Promise<Response>, [(string | Request | undefined)?, (RequestInit | undefined)?]> {
     (input?: string | Request, init?: RequestInit): Promise<Response>;
 
     mockResponse(body: BodyOrFunction, init?: MockParams): FetchMock;

--- a/types/test.ts
+++ b/types/test.ts
@@ -59,13 +59,24 @@ fetchMock.disableMocks();
 
 fetchMock.isMocking("http://bar");
 fetchMock.isMocking(new Request("http://bang"));
-fetchMock.onlyMock('http://foo');
 
-fetchMock.onlyMock(/bar/);
-fetchMock.onlyMock((input:Request|string) => true);
-fetchMock.neverMock('http://foo');
-fetchMock.neverMock(/bar/);
-fetchMock.neverMock((input:Request|string) => true);
+fetchMock.onlyMockIf('http://foo');
+fetchMock.onlyMockIf(/bar/);
+fetchMock.onlyMockIf((input:Request|string) => true);
+fetchMock.neverMockIf('http://foo');
+fetchMock.neverMockIf(/bar/);
+fetchMock.neverMockIf((input:Request|string) => true);
+fetchMock.onlyMockOnceIf('http://foo');
+fetchMock.onlyMockOnceIf(/bar/);
+fetchMock.onlyMockOnceIf((input:Request|string) => true);
+fetchMock.neverMockOnceIf('http://foo');
+fetchMock.neverMockOnceIf(/bar/);
+fetchMock.neverMockOnceIf((input:Request|string) => true);
+
+fetchMock.doMock();
+fetchMock.dontMock();
+fetchMock.doMockOnce();
+fetchMock.dontMockOnce();
 
 async function someAsyncHandler(): Promise<MockResponseInit> {
     return {

--- a/types/test.ts
+++ b/types/test.ts
@@ -62,16 +62,16 @@ fetchMock.isMocking(new Request("http://bang"));
 
 fetchMock.onlyMockIf('http://foo');
 fetchMock.onlyMockIf(/bar/);
-fetchMock.onlyMockIf((input:Request|string) => true);
+fetchMock.onlyMockIf((input: Request|string) => true);
 fetchMock.neverMockIf('http://foo');
 fetchMock.neverMockIf(/bar/);
-fetchMock.neverMockIf((input:Request|string) => true);
+fetchMock.neverMockIf((input: Request|string) => true);
 fetchMock.onlyMockOnceIf('http://foo');
 fetchMock.onlyMockOnceIf(/bar/);
-fetchMock.onlyMockOnceIf((input:Request|string) => true);
+fetchMock.onlyMockOnceIf((input: Request|string) => true);
 fetchMock.neverMockOnceIf('http://foo');
 fetchMock.neverMockOnceIf(/bar/);
-fetchMock.neverMockOnceIf((input:Request|string) => true);
+fetchMock.neverMockOnceIf((input: Request|string) => true);
 
 fetchMock.doMock();
 fetchMock.dontMock();

--- a/types/test.ts
+++ b/types/test.ts
@@ -10,6 +10,7 @@ fetchMock.mockResponse(JSON.stringify({foo: "bar"}), {
 fetchMock.mockResponse(JSON.stringify({foo: "bar"}), {});
 fetchMock.mockResponse(someAsyncHandler);
 fetchMock.mockResponse(someAsyncHandler, {});
+fetchMock.mockResponse(someAsyncStringHandler, {});
 
 fetchMock.mockResponseOnce(JSON.stringify({foo: "bar"}));
 fetchMock.mockResponseOnce(JSON.stringify({foo: "bar"}), {
@@ -21,6 +22,7 @@ fetchMock.mockResponseOnce(JSON.stringify({foo: "bar"}), {
 fetchMock.mockResponseOnce(JSON.stringify({foo: "bar"}), {});
 fetchMock.mockResponseOnce(someAsyncHandler);
 fetchMock.mockResponseOnce(someAsyncHandler, {});
+fetchMock.mockResponseOnce(someAsyncStringHandler, {});
 
 fetchMock.once(JSON.stringify({foo: "bar"}));
 fetchMock.once(JSON.stringify({foo: "bar"}), {
@@ -32,6 +34,7 @@ fetchMock.once(JSON.stringify({foo: "bar"}), {
 fetchMock.once(JSON.stringify({foo: "bar"}), {});
 fetchMock.once(someAsyncHandler);
 fetchMock.once(someAsyncHandler, {});
+fetchMock.once(someAsyncStringHandler, {});
 
 fetchMock.mockResponses(JSON.stringify({}), JSON.stringify({foo: "bar"}));
 fetchMock.mockResponses(someAsyncHandler, someAsyncHandler);
@@ -41,6 +44,7 @@ fetchMock.mockResponses([someAsyncHandler, {status: 200}]);
 fetchMock.mockResponses([JSON.stringify({foo: "bar"}), {status: 200}]);
 fetchMock.mockResponses(
     [someAsyncHandler, {status: 200}],
+    [someAsyncStringHandler, {status: 200}],
     [JSON.stringify({foo: "bar"}), {status: 200}]
 );
 
@@ -50,10 +54,26 @@ fetchMock.mockReject(someAsyncHandler);
 fetchMock.mockRejectOnce(new Error("oops"));
 fetchMock.mockRejectOnce(someAsyncHandler);
 fetchMock.resetMocks();
+fetchMock.enableMocks();
+fetchMock.disableMocks();
+
+fetchMock.isMocking("http://bar");
+fetchMock.isMocking(new Request("http://bang"));
+fetchMock.onlyMock('http://foo');
+
+fetchMock.onlyMock(/bar/);
+fetchMock.onlyMock((input:Request|string) => true);
+fetchMock.neverMock('http://foo');
+fetchMock.neverMock(/bar/);
+fetchMock.neverMock((input:Request|string) => true);
 
 async function someAsyncHandler(): Promise<MockResponseInit> {
     return {
         status: 200,
-        body: JSON.stringify({foo: "bar"})
+        body: await someAsyncStringHandler()
     };
+}
+
+async function someAsyncStringHandler(): Promise<string> {
+    return JSON.stringify({foo: "bar"});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,9 +1171,9 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-"definitelytyped-header-parser@github:Microsoft/definitelytyped-header-parser#production":
+definitelytyped-header-parser@Microsoft/definitelytyped-header-parser#production:
   version "0.0.0"
-  resolved "https://codeload.github.com/Microsoft/definitelytyped-header-parser/tar.gz/56d9f98e9acc5b4c0062aa919850b306a7616693"
+  resolved "https://codeload.github.com/Microsoft/definitelytyped-header-parser/tar.gz/d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a"
   dependencies:
     "@types/parsimmon" "^1.3.0"
     parsimmon "^1.2.0"
@@ -3210,6 +3210,11 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
+
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
This incorporates idea from #121 and #102 but with a much more robust API that supports the concept of "once".  Also adds `enableMocks` and `disableMocks` helper functions to make using the library easier.  This also adds the ability to take the 'input' and 'init' arguments from 'fetch' in to the response promise functions.  Finally it adds the ability for the response promise functions to return a string instead of an object with a body. I also added the prettier configuration that matches the 'index.d.ts' file so that those files can also be formatted with prettier.

I updated the README with all the details so I highly suggest heading over to my fork website and browsing it rendered.

* Add conditional mocking functionality
* Add response functions returning string support
* Add enableMocks and disableMocks functions
* Add optional response function input and init arguments