### PR TITLE
fixes #152 type definitions for UrlOrPredicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ describe('conditional mocking', () => {
       await expectMocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.doMockIf(input => input === testUrl)
+      fetch.doMockIf(input => input.url === testUrl)
       await expectMocked()
       await expectMocked()
     })
@@ -788,7 +788,7 @@ describe('conditional mocking', () => {
       await expectUnmocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.dontMockIf(input => input === testUrl)
+      fetch.dontMockIf(input => input.url === testUrl)
       await expectUnmocked()
       await expectUnmocked()
     })
@@ -811,7 +811,7 @@ describe('conditional mocking', () => {
       await expectMocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.doMockOnceIf(input => input === testUrl)
+      fetch.doMockOnceIf(input => input.url === testUrl)
       await expectMocked()
       await expectMocked()
     })
@@ -834,7 +834,7 @@ describe('conditional mocking', () => {
       await expectMocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.dontMockOnceIf(input => input === testUrl)
+      fetch.dontMockOnceIf(input => input.url === testUrl)
       await expectUnmocked()
       await expectMocked()
     })
@@ -860,7 +860,7 @@ describe('conditional mocking', () => {
       await expectUnmocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.doMockOnceIf(input => input === testUrl)
+      fetch.doMockOnceIf(input => input.url === testUrl)
       await expectMocked()
       await expectUnmocked()
     })
@@ -886,7 +886,7 @@ describe('conditional mocking', () => {
       await expectUnmocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.dontMockOnceIf(input => input === testUrl)
+      fetch.dontMockOnceIf(input => input.url === testUrl)
       await expectUnmocked()
       await expectUnmocked()
     })

--- a/tests/test.js
+++ b/tests/test.js
@@ -429,7 +429,7 @@ describe('conditional mocking', () => {
       await expectMocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.doMockIf(input => input === testUrl)
+      fetch.doMockIf(input => input.url === testUrl)
       await expectMocked()
       await expectMocked()
     })
@@ -452,7 +452,7 @@ describe('conditional mocking', () => {
       await expectUnmocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.dontMockIf(input => input === testUrl)
+      fetch.dontMockIf(input => input.url === testUrl)
       await expectUnmocked()
       await expectUnmocked()
     })
@@ -468,10 +468,10 @@ describe('conditional mocking', () => {
       const response = 'blah'
       const response2 = 'blah2'
       fetch
-        .doMockOnceIf('http://foo', response)
-        .doMockOnceIf('http://foo2', response2)
-      await expectMocked('http://foo', response)
-      await expectMocked('http://foo2', response2)
+        .doMockOnceIf('http://foo/', response)
+        .doMockOnceIf('http://foo2/', response2)
+      await expectMocked('http://foo/', response)
+      await expectMocked('http://foo2/', response2)
       //await expectMocked('http://foo3', mockedDefaultResponse)
     })
     it('mocks when matches regex', async () => {
@@ -480,7 +480,7 @@ describe('conditional mocking', () => {
       await expectMocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.doMockOnceIf(input => input === testUrl)
+      fetch.doMockOnceIf(input => input.url === testUrl)
       await expectMocked()
       await expectMocked()
     })
@@ -503,7 +503,7 @@ describe('conditional mocking', () => {
       await expectMocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.dontMockOnceIf(input => input === testUrl)
+      fetch.dontMockOnceIf(input => input.url === testUrl)
       await expectUnmocked()
       await expectMocked()
     })
@@ -529,7 +529,7 @@ describe('conditional mocking', () => {
       await expectUnmocked()
     })
     it('mocks when matches predicate', async () => {
-      fetch.doMockOnceIf(input => input === testUrl)
+      fetch.doMockOnceIf(input => input.url === testUrl)
       await expectMocked()
       await expectUnmocked()
     })
@@ -555,7 +555,7 @@ describe('conditional mocking', () => {
       await expectUnmocked()
     })
     it('doesnt mock when matches predicate', async () => {
-      fetch.dontMockOnceIf(input => input === testUrl)
+      fetch.dontMockOnceIf(input => input.url === testUrl)
       await expectUnmocked()
       await expectUnmocked()
     })


### PR DESCRIPTION
This PR fixes Issue #152 however it technically changes the behavior of the library if you were not using the TypeScript definition as it now follows the TypeScript definitions correctly.  

Anyone who used the recent "condition mocking" functionality may need to make a change to their code.

If they passed a conditional URL string without a path (i.e. http://foo.com) they must append a trailing slash or it will never match (as the ".url" property of a request always has a path). For regexs, they will match against the URL with the trailing slash.

If they passed a predicate function, that function is now passed a fetch "Request" object instead of the url string (as was previously defined in the TypeScript definitions).

