### PR TITLE
fix file name of setupJest.js in the CRA section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You may also need to edit your `tsconfig.json` and add "dom" and/or "es2015" and
 
 ### Using with Create-React-App
 
-If you are using [Create-React-App](https://github.com/facebookincubator/create-react-app) (CRA), the code for `setupTest.js` above should be placed into `src/setupTests.js` in the root of your project. CRA automatically uses this filename by convention in the Jest configuration it generates. Similarly, changing to your `package.json` is not required as CRA handles this when generating your Jest configuration.
+If you are using [Create-React-App](https://github.com/facebookincubator/create-react-app) (CRA), the code for `setupJest.js` above should be placed into `src/setupTests.js` in the root of your project. CRA automatically uses this filename by convention in the Jest configuration it generates. Similarly, changing to your `package.json` is not required as CRA handles this when generating your Jest configuration.
 
 ### For Ejected Create React Apps _ONLY_:
 


### PR DESCRIPTION
In the section "Using with Create-React-App" of the Readme the name of the setup file is wrong.
"setupTest.js" was changed to "setupJest.js"