### PR TITLE
Adds polyfill for DOMException

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/jefflau/jest-fetch-mock#readme",
   "dependencies": {
     "cross-fetch": "^3.0.4",
+    "domexception": "^2.0.1",
     "promise-polyfill": "^8.1.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,10 @@ if (!Promise) {
   Promise.finally = require('promise-polyfill').finally
 }
 
+if (typeof DOMException === 'undefined') {
+  global.DOMException = require("domexception");
+}
+
 const ActualResponse = Response
 
 function responseWrapper(body, init) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,6 +833,13 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+domexception@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
+  integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
+  dependencies:
+    webidl-conversions "^5.0.0"
+
 dts-critic@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/dts-critic/-/dts-critic-2.2.3.tgz#37b6b604dd2df77d960e59ab501aadc165ef6309"
@@ -3766,6 +3773,11 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.5"


### PR DESCRIPTION
Fixes #159

I added the [DOMException](https://www.npmjs.com/package/domexception) package as a polyfill.

I tested it against my repo where I was facing the same issue related at #159 and it works! :)

I ran all tests, all passes, but there is some issue around the types processing. But it doesn't seem to be related to my change.