### PR TITLE
Mocking redirected

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ describe('Mocking aborts', () => {
 
 
 ### Mocking a redirected response
-Use the counter option in the response init object to mock a redirected response https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected. 
+Set the counter option >= 1 in the response init object to mock a redirected response https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected. 
 
 ```js
 fetchMock.mockResponse("<main></main>", {

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ describe('Mocking aborts', () => {
 
 
 ### Mocking a redirected response
-Set the counter option >= 1 in the response init object to mock a redirected response https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected. 
+Set the counter option >= 1 in the response init object to mock a redirected response https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected. Note, this will only work in Node.js as it's a feature of node fetch's response class https://github.com/node-fetch/node-fetch/blob/master/src/response.js#L39.
 
 ```js
 fetchMock.mockResponse("<main></main>", {

--- a/README.md
+++ b/README.md
@@ -395,6 +395,18 @@ describe('Mocking aborts', () => {
 })
 ```
 
+
+### Mocking a redirected response
+Use the counter option in the response init object to mock a redirected response https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected. 
+
+```js
+fetchMock.mockResponse("<main></main>", {
+  counter: 1,
+  status: 200,
+  statusText: "ok",
+});
+```
+
 ### Mocking multiple fetches with different responses
 
 In this next example, the store does not yet have a token, so we make a request to get an access token first. This means that we need to mock two different responses, one for each of the fetches. Here we can use `fetch.mockResponseOnce` or `fetch.once` to mock the response only once and call it twice. Because we return the mocked function, we can chain this jQuery style. It internally uses Jest's `mockImplementationOnce`. You can read more about it on the [Jest documentation](https://facebook.github.io/jest/docs/mock-functions.html#content)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,7 +86,8 @@ export interface MockParams {
     statusText?: string;
     headers?: string[][] | { [key: string]: string }; // HeadersInit
     url?: string;
-    counter?: number; // Set >= 1 to have redirected return true. https://github.com/node-fetch/node-fetch/blob/master/src/response.js#L39
+    /** Set >= 1 to have redirected return true. */
+    counter?: number;
 }
 
 export interface MockResponseInit extends MockParams {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,6 +86,7 @@ export interface MockParams {
     statusText?: string;
     headers?: string[][] | { [key: string]: string }; // HeadersInit
     url?: string;
+    counter?: number; // Set >= 1 to have redirected return true. https://github.com/node-fetch/node-fetch/blob/master/src/response.js#L39
 }
 
 export interface MockResponseInit extends MockParams {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,7 +86,7 @@ export interface MockParams {
     statusText?: string;
     headers?: string[][] | { [key: string]: string }; // HeadersInit
     url?: string;
-    /** Set >= 1 to have redirected return true. */
+    /** Set >= 1 to have redirected return true. Only applicable to Node.js */
     counter?: number;
 }
 


### PR DESCRIPTION
node-fetch takes a counter option that allows user to mock redirects https://github.com/node-fetch/node-fetch/blob/master/src/response.js#L39