### PR TITLE
Add async to mockIf callback in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To enable mocking for a specific URL only:
 ```js
 beforeEach(() => {
   // if you have an existing `beforeEach` just add the following lines to it
-  fetchMock.mockIf(/^https?:\/\/example.com.*$/, req => {
+  fetchMock.mockIf(/^https?:\/\/example.com.*$/, async (req) => {
     if (req.url.endsWith('/path1')) {
       return 'some response body'
     } else if (req.url.endsWith('/path2')) {


### PR DESCRIPTION
The callback function passed into mockIf() should be an async function. I followed this example down to the letter but it wouldn't work until I put an async in front of the callback - evidently there is a function somewhere in the stack that requires it.