### PR TITLE
Fix global `resetMock: true` breaking fetch mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-fetch-mock",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "fetch mock for jest",
   "main": "src/index.js",
   "types": "types",

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,10 @@ function staticMatches(value) {
 const isFn = (unknown) => typeof unknown === 'function'
 
 const isMocking = jest.fn(staticMatches(true))
+beforeEach(() => {
+  // This fixes errors caused by `resetMocks: true` being set in jest.config.js
+  isMocking = jest.fn(staticMatches(true))
+})
 
 const abortError = () =>
   new DOMException('The operation was aborted. ', 'AbortError')
@@ -147,6 +151,11 @@ const normalizeError = (errorOrFunction) =>
     : () => Promise.reject(errorOrFunction)
 
 const fetch = jest.fn(normalizeResponse(''))
+beforeEach(() => {
+  // This fixes errors caused by `resetMocks: true` being set in jest.config.js
+  fetch = jest.fn(normalizeResponse(''))
+})
+
 fetch.Headers = Headers
 fetch.Response = responseWrapper
 fetch.Request = Request


### PR DESCRIPTION
**Overview**
When developers set `resetMock` to `true` in their `jest.config.js`, it breaks the automocking. This can be seen by errors surfacing saying `isMocking is not a function or its return value is not iterable` or related.

This fixes that issue by resetting the `isMocking` and global `fetch` functions by resetting their values in a `beforeEach` call.

A PR has been opened in the original repo here: https://github.com/jefflau/jest-fetch-mock/pull/197