### PR TITLE
Make input a required argument to fetch

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,7 +18,7 @@ export interface GlobalWithFetchMock extends Global {
 
 export interface FetchMock
     extends jest.MockInstance<Promise<Response>, [string | Request | undefined, RequestInit | undefined]> {
-    (input?: string | Request, init?: RequestInit): Promise<Response>;
+    (input: string | Request, init?: RequestInit): Promise<Response>;
 
     // Response mocking
     mockResponse(fn: MockResponseInitFunction): FetchMock;


### PR DESCRIPTION
See https://github.com/jefflau/jest-fetch-mock/issues/206 , this is an attempt to correct the type definitions for the mocked `fetch`.

I ran the unit tests, `tsc`, and lint locally, but I'm unsure what else I should be checking.