### PR TITLE
Apollo Server 3 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^10.17.40",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",
+    "apollo-server-env": "^4.1.0",
     "eslint": "^7.11.0",
     "jest": "^26.6.0",
     "prettier": "^2.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ const normalizeResponse = (bodyOrFunction, init) => (input, reqInit) => {
 }
 
 const normalizeRequest = (input, reqInit) => {
-  if (input instanceof Request) {
+  if (input.constructor.toString().startsWith('class Request')) {
     if (input.signal && input.signal.aborted) {
       abort()
     }

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,5 @@
 const { APIRequest, APIRequest2, defaultRequestUri, request } = require('./api')
+const { Request: ApolloRequest } = require('apollo-server-env')
 
 describe('testing mockResponse and alias once', () => {
   beforeEach(() => {
@@ -424,6 +425,16 @@ describe('conditional mocking', () => {
       fetch.doMockIf((input) => input.url === testUrl)
       await expectMocked()
       await expectMocked()
+    })
+    it('supports request objects', async () => {
+      fetch.doMockIf(defaultRequestUri)
+      await expectMocked(new Request({ href: defaultRequestUri }))
+      await expectUnmocked(new Request({ href: 'http://foo' }))
+    })
+    it.skip('supports Apollo request objects', async () => {
+      fetch.doMockIf(defaultRequestUri)
+      await expectMocked(new ApolloRequest({ href: defaultRequestUri }))
+      await expectUnmocked(new ApolloRequest({ href: 'http://foo' }))
     })
   })
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -431,7 +431,7 @@ describe('conditional mocking', () => {
       await expectMocked(new Request({ href: defaultRequestUri }))
       await expectUnmocked(new Request({ href: 'http://foo' }))
     })
-    it.skip('supports Apollo request objects', async () => {
+    it('supports Apollo request objects', async () => {
       fetch.doMockIf(defaultRequestUri)
       await expectMocked(new ApolloRequest({ href: defaultRequestUri }))
       await expectUnmocked(new ApolloRequest({ href: 'http://foo' }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,6 +797,13 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apollo-server-env@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-4.1.0.tgz#20b69216d87b4e73166b28d2675e72823655fe75"
+  integrity sha512-pJIqIN7UXYDHcNY/IRi7H9AvdV+aHi96gv/nPmnLsP/LbWMJvMuQY3jQ2obW0P+rO3bx05oYHLsVjwHHaXlEQA==
+  dependencies:
+    node-fetch "^2.6.1"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -2934,6 +2941,13 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^2.6.1:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
+  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -3886,6 +3900,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -4053,6 +4072,11 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -4074,6 +4098,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0:
   version "8.4.0"


### PR DESCRIPTION
Apollo Server 3 [changed the type definitions](https://www.apollographql.com/docs/apollo-server/migration/#apollo-server-envs-global-type-definitions) it uses for the Fetch API. The `Request` object it now uses can no longer be identified using `instanceof Request`, breaking `jest-fetch-mock` in the case where `Request` objects are being passed. This can be mitigated by identifying using the name of the class used to construct the `Request` object, which works in both cases.

The first commit tests the status quo, while the second commit enables support for Apollo Server 3.