### PR TITLE
chore(types): fetch now also accepts URL in addition to RequestInfo

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,7 +18,7 @@ export interface GlobalWithFetchMock extends Global {
 
 export interface FetchMock
     extends jest.MockInstance<Promise<Response>, [string | Request | undefined, RequestInit | undefined]> {
-    (input: string | Request, init?: RequestInit): Promise<Response>;
+    (input: string | Request | URL, init?: RequestInit): Promise<Response>;
 
     // Response mocking
     mockResponse(fn: MockResponseInitFunction): FetchMock;


### PR DESCRIPTION
As of TypesScript v4.7, `fetch` now also accepts `URL` in addition to `RequestInfo` for the first parameter. Updating the `input` type resolves the following error:

<img width="764" alt="CleanShot 2022-07-15 at 14 35 50@2x" src="https://user-images.githubusercontent.com/5139846/179289877-3fa6a9fa-b506-4b5c-a321-64002dc46a30.png">