### PR TITLE
Modernize CI and npm publishing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,22 +1,20 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# then publish the resulting package to NPM js
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# Runs the test suite (jest, tsc, eslint) across supported Node versions
 
 name: Node.js CI
 
 on:
   push:
+    branches: [ master ]
   pull_request:
-      branches: [ master ]
+    branches: [ master ]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -24,7 +22,8 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
+        cache: yarn
+    - run: yarn install --frozen-lockfile
+    - run: yarn test
       env:
         CI: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,28 +1,48 @@
-# This workflow will do a clean install of node dependencies and publishes via npm
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# Publishes to npm when a version tag (v*) is pushed, using OIDC trusted publishing:
+# https://docs.npmjs.com/trusted-publishers
+# Prerelease tags (e.g. v3.2.0-beta.1) publish to the "next" dist-tag; stable tags to "latest".
+# The npm package's Trusted Publisher must be configured for this repo and workflow file.
 
-name: Node.js Publish CI
+name: Publish to npm
 
 on:
-  pull_request:
-    types: [ closed ]
-    branches: [ master ]
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
-  build:
-    if: github.event.pull_request.merged == true
+  publish:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
         env:
           CI: true
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}
+      - name: Check tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)" >&2
+            exit 1
+          fi
+      - name: Publish
+        run: |
+          case "$GITHUB_REF_NAME" in
+            *-*) npm publish --tag next ;;
+            *)   npm publish ;;
+          esac

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,10 @@ node_modules
 coverage
 .idea
 .vscode
+.github
+.editorconfig
+.eslintrc.js
+.prettierignore
+tsconfig.json
+types/test.ts
+types/tsconfig.json


### PR DESCRIPTION
Modernizes the release infrastructure ahead of the 3.2.0 release:

- CI now tests on Node 18/20/22/24 (the old matrix was 16/18/20 and had never actually run) and caches yarn installs
- The publish workflow no longer fires on every merged PR with a classic npm token (classic tokens were revoked registry-wide in Dec 2025); it now runs on version tags (`v*`), verifies the tag matches `package.json`, runs the full suite, and publishes via [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) — prerelease tags go to the `next` dist-tag, stable tags to `latest`
- The npm tarball no longer ships workflow files, lint configs, or type-test files (the 3.0.3 tarball even shipped coverage reports)