### PR TITLE
3.2.0: TypeScript fixes, Response object support, spec-compliant aborts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+## 3.2.0 (unreleased)
+
+First release since 3.0.3 (March 2020). Everything merged to master in the intervening years ships in this release, plus a round of new fixes. Version 3.1.0 was tagged in 2024 but never published to npm; its contents are included here.
+
+### Added
+
+- Pass a `Response` object directly to `mockResponse`, `mockResponseOnce`, `once`, `mockResponses` and the conditional mocking functions — including responses with binary (`Buffer`) bodies ([#223], thanks [@alexkolson])
+- Response functions can return a `Response` object (sync or async)
+- `URL` objects (and anything else with a `toString`) accepted as fetch input ([#193])
+- Mock `redirected` responses via the `counter` param in response init ([#168])
+- Response functions may be synchronous — no need to return a promise ([#145])
+- `engines` field declaring the Node >= 12 floor (required by the `domexception` dependency)
+
+### Fixed
+
+- TypeScript definitions no longer import `NodeJS.Global`, which was removed from `@types/node` — types now work with modern `@types/node`/TypeScript setups ([#184], [#201], [#248])
+- `fetch()` called with an already-aborted signal now rejects (as per the fetch spec) instead of throwing synchronously, so it can be caught with `.catch()` ([#237])
+- `fetch.isMocking` returns a plain boolean again after `resetMocks()` ([#183])
+- `DOMException` is polyfilled in Node environments, fixing `mockAbort` under `jest-environment-node` ([#159])
+- TypeScript: `mockIf`/`doMockIf` callbacks may return synchronously ([#220])
+
+### Changed
+
+- TypeScript: fetch's `input` argument is now required, matching the DOM signature ([#206], [#207])
+- `cross-fetch` floor raised to ^3.1.8 (security fixes in transitive `node-fetch`) ([#228], [#249])
+- The npm tarball no longer ships tooling configs, workflow files, or type-test files
+- npm publishing now happens via GitHub Actions [trusted publishing](https://docs.npmjs.com/trusted-publishers) with provenance
+
+[#145]: https://github.com/jefflau/jest-fetch-mock/issues/145
+[#159]: https://github.com/jefflau/jest-fetch-mock/issues/159
+[#168]: https://github.com/jefflau/jest-fetch-mock/issues/168
+[#183]: https://github.com/jefflau/jest-fetch-mock/issues/183
+[#184]: https://github.com/jefflau/jest-fetch-mock/issues/184
+[#193]: https://github.com/jefflau/jest-fetch-mock/issues/193
+[#201]: https://github.com/jefflau/jest-fetch-mock/issues/201
+[#206]: https://github.com/jefflau/jest-fetch-mock/issues/206
+[#207]: https://github.com/jefflau/jest-fetch-mock/pull/207
+[#220]: https://github.com/jefflau/jest-fetch-mock/issues/220
+[#223]: https://github.com/jefflau/jest-fetch-mock/pull/223
+[#228]: https://github.com/jefflau/jest-fetch-mock/pull/228
+[#237]: https://github.com/jefflau/jest-fetch-mock/issues/237
+[#248]: https://github.com/jefflau/jest-fetch-mock/issues/248
+[#249]: https://github.com/jefflau/jest-fetch-mock/issues/249
+[@alexkolson]: https://github.com/alexkolson
+
+## 3.0.3 and earlier
+
+See the [GitHub releases](https://github.com/jefflau/jest-fetch-mock/releases).

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you are using [Create-React-App](https://github.com/facebookincubator/create-
 ### Functions
 
 Instead of passing body, it is also possible to pass a function that returns a promise.
-The promise should resolve with a string or an object containing body and init props
+The promise should resolve with a string, an object containing body and init props, or a `Response` object
 
 i.e:
 
@@ -186,6 +186,14 @@ i.e:
 fetch.mockResponse(() => callMyApi().then(res => ({ body: 'ok' })))
 // OR
 fetch.mockResponse(() => callMyApi().then(res => 'ok'))
+// OR
+fetch.mockResponse(() => callMyApi().then(res => new Response('ok')))
+```
+
+A `Response` can also be passed directly (note that its body can only be read once, so prefer `mockResponseOnce`/a function returning a fresh `Response` over `mockResponse` when fetch is called repeatedly):
+
+```js
+fetch.mockResponseOnce(new Response(Buffer.from('some binary data')))
 ```
 
 The function may take an optional "request" parameter of type `http.Request`:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   ],
   "author": "Jeff Lau <jeff-lau@live.com> (http://jefflau.net/)",
   "license": "MIT",
+  "engines": {
+    "node": ">=12"
+  },
   "bugs": {
     "url": "https://github.com/jefflau/jest-fetch-mock/issues"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,15 @@ const abortAsync = () => {
 const toPromise = (val) => (val instanceof Promise ? val : Promise.resolve(val))
 
 const normalizeResponse = (bodyOrFunction, init) => (input, reqInit) => {
-  const [mocked, request] = isMocking(input, reqInit)
+  let mockResult
+  try {
+    mockResult = isMocking(input, reqInit)
+  } catch (error) {
+    // fetch() never throws synchronously: an already-aborted signal or
+    // unparseable input must surface as a rejected promise
+    return Promise.reject(error)
+  }
+  const [mocked, request] = mockResult
   return mocked
     ? isFn(bodyOrFunction)
       ? toPromise(bodyOrFunction(request)).then((resp) => {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,10 @@ if (typeof DOMException === 'undefined') {
 const ActualResponse = Response
 
 function responseWrapper(body, init) {
+  if (body instanceof ActualResponse) {
+    return body
+  }
+
   if (
     body &&
     typeof body.constructor === 'function' &&
@@ -105,6 +109,9 @@ const normalizeResponse = (bodyOrFunction, init) => (input, reqInit) => {
       ? toPromise(bodyOrFunction(request)).then((resp) => {
           if (request.signal && request.signal.aborted) {
             abort()
+          }
+          if (resp instanceof ActualResponse) {
+            return resp
           }
           return typeof resp === 'string'
             ? responseWrapper(resp, init)

--- a/tests/test.js
+++ b/tests/test.js
@@ -141,10 +141,10 @@ describe('Mocking aborts', () => {
     await expect(request()).resolves.toEqual('')
   })
 
-  it('throws when passed an already aborted abort signal in the request init', () => {
+  it('rejects when passed an already aborted abort signal in the request init', () => {
     const c = new AbortController()
     c.abort()
-    expect(() => fetch('/', { signal: c.signal })).toThrow(
+    return expect(fetch('/', { signal: c.signal })).rejects.toThrow(
       expect.any(DOMException)
     )
   })

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,3 +1,4 @@
+const { StringDecoder } = require('string_decoder')
 const { APIRequest, APIRequest2, defaultRequestUri, request } = require('./api')
 
 describe('testing mockResponse and alias once', () => {
@@ -357,6 +358,30 @@ describe('request', () => {
     return expect(
       fetch('https://bar', {}).then((response) => response.headers.get('ding'))
     ).resolves.toEqual('dang')
+  })
+
+  it('accepts a function that resolves with a Response', () => {
+    fetch.mockResponseOnce(() =>
+      Promise.resolve(new Response(Buffer.from('foo')))
+    )
+    return expect(
+      fetch('https://bar', {})
+        .then((response) => response.arrayBuffer())
+        .then((arrayBuffer) =>
+          new StringDecoder('utf8').write(new Uint8Array(arrayBuffer))
+        )
+    ).resolves.toEqual('foo')
+  })
+
+  it('accepts a Response', () => {
+    fetch.mockResponseOnce(new Response(Buffer.from('foo')))
+    return expect(
+      fetch('https://bar', {})
+        .then((response) => response.arrayBuffer())
+        .then((arrayBuffer) =>
+          new StringDecoder('utf8').write(new Uint8Array(arrayBuffer))
+        )
+    ).resolves.toEqual('foo')
   })
 })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,6 @@
 // TypeScript Version: 3.0
+/// <reference types="jest" />
 /// <reference lib="dom" />
-import Global = NodeJS.Global;
-import "jest";
 
 declare global {
     const fetchMock: FetchMock;
@@ -12,9 +11,14 @@ declare global {
     }
 }
 
-export interface GlobalWithFetchMock extends Global {
+/**
+ * @deprecated Cast your global object to `typeof globalThis & { fetchMock: FetchMock }`
+ * instead. Kept for backwards compatibility with older setup guides.
+ */
+export interface GlobalWithFetchMock {
     fetchMock: FetchMock;
     fetch: FetchMock;
+    [key: string]: any;
 }
 
 export interface FetchMock
@@ -24,15 +28,18 @@ export interface FetchMock
     // Response mocking
     mockResponse(fn: MockResponseInitFunction): FetchMock;
     mockResponse(response: string, responseInit?: MockParams): FetchMock;
+    mockResponse(response: Response): FetchMock;
 
     mockResponseOnce(fn: MockResponseInitFunction): FetchMock;
     mockResponseOnce(response: string, responseInit?: MockParams): FetchMock;
+    mockResponseOnce(response: Response): FetchMock;
 
     // alias for mockResponseOnce
     once(fn: MockResponseInitFunction): FetchMock;
     once(url: string, responseInit?: MockParams): FetchMock;
+    once(response: Response): FetchMock;
 
-    mockResponses(...responses: Array<string | [string, MockParams] | MockResponseInitFunction>): FetchMock;
+    mockResponses(...responses: Array<string | Response | [string, MockParams] | MockResponseInitFunction>): FetchMock;
 
     // Error/Reject mocking
     mockReject(error?: ErrorOrFunction): FetchMock;
@@ -46,36 +53,47 @@ export interface FetchMock
 
     doMock(fn?: MockResponseInitFunction): FetchMock;
     doMock(response: string, responseInit?: MockParams): FetchMock;
+    doMock(response: Response): FetchMock;
 
     doMockOnce(fn?: MockResponseInitFunction): FetchMock;
     doMockOnce(response: string, responseInit?: MockParams): FetchMock;
+    doMockOnce(response: Response): FetchMock;
     // alias for doMockOnce
     mockOnce(fn?: MockResponseInitFunction): FetchMock;
     mockOnce(response: string, responseInit?: MockParams): FetchMock;
+    mockOnce(response: Response): FetchMock;
 
     doMockIf(urlOrPredicate: UrlOrPredicate, fn?: MockResponseInitFunction): FetchMock;
     doMockIf(urlOrPredicate: UrlOrPredicate, response: string, responseInit?: MockParams): FetchMock;
+    doMockIf(urlOrPredicate: UrlOrPredicate, response: Response): FetchMock;
     // alias for doMockIf
     mockIf(urlOrPredicate: UrlOrPredicate, fn?: MockResponseInitFunction): FetchMock;
     mockIf(urlOrPredicate: UrlOrPredicate, response: string, responseInit?: MockParams): FetchMock;
+    mockIf(urlOrPredicate: UrlOrPredicate, response: Response): FetchMock;
 
     doMockOnceIf(urlOrPredicate: UrlOrPredicate, fn?: MockResponseInitFunction): FetchMock;
     doMockOnceIf(urlOrPredicate: UrlOrPredicate, response: string, responseInit?: MockParams): FetchMock;
-    // alias for doMocKOnceIf
+    doMockOnceIf(urlOrPredicate: UrlOrPredicate, response: Response): FetchMock;
+    // alias for doMockOnceIf
     mockOnceIf(urlOrPredicate: UrlOrPredicate, fn?: MockResponseInitFunction): FetchMock;
     mockOnceIf(urlOrPredicate: UrlOrPredicate, response: string, responseInit?: MockParams): FetchMock;
+    mockOnceIf(urlOrPredicate: UrlOrPredicate, response: Response): FetchMock;
 
     dontMock(fn?: MockResponseInitFunction): FetchMock;
     dontMock(response: string, responseInit?: MockParams): FetchMock;
+    dontMock(response: Response): FetchMock;
 
     dontMockOnce(fn?: MockResponseInitFunction): FetchMock;
     dontMockOnce(response: string, responseInit?: MockParams): FetchMock;
+    dontMockOnce(response: Response): FetchMock;
 
     dontMockIf(urlOrPredicate: UrlOrPredicate, fn?: MockResponseInitFunction): FetchMock;
     dontMockIf(urlOrPredicate: UrlOrPredicate, response: string, responseInit?: MockParams): FetchMock;
+    dontMockIf(urlOrPredicate: UrlOrPredicate, response: Response): FetchMock;
 
     dontMockOnceIf(urlOrPredicate: UrlOrPredicate, fn?: MockResponseInitFunction): FetchMock;
     dontMockOnceIf(urlOrPredicate: UrlOrPredicate, response: string, responseInit?: MockParams): FetchMock;
+    dontMockOnceIf(urlOrPredicate: UrlOrPredicate, response: Response): FetchMock;
 
     resetMocks(): void;
     enableMocks(): void;
@@ -99,7 +117,9 @@ export interface MockResponseInit extends MockParams {
 export type ErrorOrFunction = Error | ((...args: any[]) => Promise<any>);
 export type UrlOrPredicate = string | RegExp | ((input: Request) => boolean);
 
-export type MockResponseInitFunction = (request: Request) => MockResponseInit | string | Promise<MockResponseInit | string>;
+export type MockResponseInitFunction = (
+    request: Request
+) => MockResponseInit | string | Response | Promise<MockResponseInit | string | Response>;
 
 // alias of fetchMock.enableMocks() for ES6 import syntax to not clash with other libraries
 export function enableFetchMocks(): void;

--- a/types/test.ts
+++ b/types/test.ts
@@ -8,8 +8,10 @@ fetchMock.mockResponse(JSON.stringify({foo: "bar"}), {
     ]
 });
 fetchMock.mockResponse(JSON.stringify({foo: "bar"}), {});
+fetchMock.mockResponse(new Response('foo'));
 fetchMock.mockResponse(someAsyncHandler);
 fetchMock.mockResponse(someAsyncStringHandler);
+fetchMock.mockResponse(someAsyncResponseHandler);
 
 fetchMock.mockResponseOnce(JSON.stringify({foo: "bar"}));
 fetchMock.mockResponseOnce(JSON.stringify({foo: "bar"}), {
@@ -19,8 +21,10 @@ fetchMock.mockResponseOnce(JSON.stringify({foo: "bar"}), {
     ]
 });
 fetchMock.mockResponseOnce(JSON.stringify({foo: "bar"}), {});
+fetchMock.mockResponseOnce(new Response('foo'));
 fetchMock.mockResponseOnce(someAsyncHandler);
 fetchMock.mockResponseOnce(someAsyncStringHandler);
+fetchMock.mockResponseOnce(someAsyncResponseHandler);
 
 fetchMock.once(JSON.stringify({foo: "bar"}));
 fetchMock.once(JSON.stringify({foo: "bar"}), {
@@ -30,7 +34,9 @@ fetchMock.once(JSON.stringify({foo: "bar"}), {
     ]
 });
 fetchMock.once(JSON.stringify({foo: "bar"}), {});
+fetchMock.once(new Response('foo'));
 fetchMock.once(someAsyncHandler);
+fetchMock.once(someAsyncResponseHandler);
 
 fetchMock.mockResponses(JSON.stringify({}), JSON.stringify({foo: "bar"}));
 fetchMock.mockResponses(someAsyncHandler, someAsyncHandler);
@@ -38,11 +44,14 @@ fetchMock.mockResponses(JSON.stringify({}), someAsyncHandler);
 fetchMock.mockResponses(someAsyncHandler, JSON.stringify({}));
 fetchMock.mockResponses(someAsyncHandler);
 fetchMock.mockResponses([JSON.stringify({foo: "bar"}), {status: 200}]);
+fetchMock.mockResponses(new Response('foo'));
+fetchMock.mockResponses(JSON.stringify({}), new Response('foo'));
 fetchMock.mockResponses(
     someSyncHandler,
     someAsyncHandler,
     someSyncStringHandler,
     someAsyncStringHandler,
+    someAsyncResponseHandler,
     [JSON.stringify({foo: "bar"}), {status: 200}]
 );
 
@@ -103,6 +112,10 @@ async function someAsyncStringHandler(): Promise<string> {
 
 function someSyncStringHandler(): string {
     return JSON.stringify({foo: "bar"});
+}
+
+async function someAsyncResponseHandler(): Promise<Response> {
+    return new Response(Buffer.from('foo'));
 }
 
 enableFetchMocks();


### PR DESCRIPTION
The code changes for the upcoming 3.2.0 release (first npm release since 3.0.3):

- **TypeScript definitions work with modern `@types/node` again** — no more `NodeJS.Global` import, explicit `/// <reference types="jest" />`. Fixes the largest class of TS breakage reported (#184, #201, #248 era).
- **`Response` objects accepted by all mock functions** (including Buffer/binary bodies), adapted from #223 by @alexkolson with type overloads and tests.
- **Aborted signals reject instead of throwing synchronously**, matching the fetch spec so the error is catchable (#237). Unparseable input also rejects (TypeError) rather than throwing.
- **`engines: node >=12`** declared (required by the `domexception` dependency master already has) and a CHANGELOG covering everything since 3.0.3.