### PR TITLE
Test hardening, integration suite, code compression

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  ignorePatterns: ['integration/'],
   env: {
     browser: true,
     commonjs: true,

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,3 +27,20 @@ jobs:
     - run: yarn test
       env:
         CI: true
+
+  integration:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 24.x]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: bash integration/run.sh
+      env:
+        CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ npm-debug.log
 yarn-error.log
 coverage
 .idea
+integration/fixtures/*/package-lock.json
+jest-fetch-mock-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 tests
+integration
 yarn.lock
 node_modules
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md — working knowledge for maintainers and coding agents
+
+jest-fetch-mock is a fetch mock for Jest: ~1.4M npm downloads/week. It was dormant 2020–2026 (npm stuck at 3.0.3 while master accumulated fixes) and was revived in July 2026 with the 3.2.0 release. This file captures how the project works and what has been learned, so anyone — human or agent — can continue from here.
+
+## Architecture
+
+- `src/index.js` — the entire implementation, single CommonJS file, ~250 lines. On require it assigns `global.fetch/Response/Headers/Request` from **cross-fetch** (node-fetch 2 under Node) and wraps fetch in a `jest.fn()`. Conditional mocking is a second `jest.fn()` (`isMocking`) whose implementation decides mock vs. passthrough per call; all eight conditional functions route through `configureMocking(once, matcher, body, init)`.
+- `types/index.d.ts` — hand-written definitions. They depend on the global `jest` namespace (consumers need `@types/jest`) and `/// <reference lib="dom" />`. **Do not reintroduce `import Global = NodeJS.Global`** — it was removed from `@types/node` and broke consumers for years.
+- `types/test.ts` — compile-only type assertions, checked by `yarn tsc`.
+- Runtime deps: `cross-fetch` (the fetch implementation + passthrough target) and `domexception` (only needed on Node < 17; engines floor is Node 12). `promise-polyfill` was removed as dead code.
+
+## Commands
+
+- `yarn install && yarn test` — jest (with **enforced coverage thresholds**: 98% statements / 96% branches / 100% functions / 98% lines) + `tsc` (type tests) + `eslint`.
+- `bash integration/run.sh` — packs the tarball and runs six consumer fixtures against it (see `integration/README.md`). **This is the release gate.**
+- Local publishes are never done; see Releases.
+
+## Releases
+
+1. Update `CHANGELOG.md`, bump `package.json` version in a commit named exactly the version (e.g. `3.2.0`).
+2. Tag `v<version>` and push the tag. `.github/workflows/publish.yml` re-runs the suite, verifies tag == package.json version, and publishes via **npm trusted publishing** (OIDC — no tokens anywhere; provenance is automatic). Prerelease tags (any tag containing `-`, e.g. `v3.2.0-beta.2`) go to the `next` dist-tag; stable tags to `latest`.
+3. **Write a proper GitHub release for every tag** (mark betas as prereleases). Group changes, link issues/PRs, credit contributors. There were no releases 2019–2026; that must not happen again.
+4. Verify after publishing: `npm view jest-fetch-mock dist-tags`, then a clean-room `npm i jest-fetch-mock@<tag>` + smoke test.
+5. Gates: integration suite green before tagging; **nothing goes to `latest` without the maintainer's (Jeff Lau) explicit approval**. Betas to `next` may ship autonomously.
+
+npm account notes: the package is npm "high-impact" (mandatory 2FA); avoid account email/2FA changes near release windows — they trigger a 72-hour publishing freeze. Sole owner: `jefflau`.
+
+## Conventions
+
+- Commit messages: plain imperative style ("Fix …", "Add …"), body explains why. **No AI attribution anywhere** — no AI co-author trailers or "generated with" footers in commits, PRs, releases, or issue comments.
+- Credit community contributors: when adapting a stale community PR, keep them as `Co-authored-by` and thank them on the PR (e.g. #223 was landed this way after 4.6 years).
+- Strict semver. The 3.x line must never break API or behavior except spec-compliance bug fixes (documented in CHANGELOG). Breaking work goes to 4.0.0 behind a beta soak on `next`.
+- PRs merge with merge commits (repo convention). CI (unit matrix Node 18/20/22/24 + integration on 20/24) must be green.
+
+## Behavioral subtleties (hard-won; tests pin all of these)
+
+- **`resetMocks: true` in a consumer's Jest config** wipes the mock implementation after setup — fetch resolves `undefined`. Most-reported issue ever (#81, #78, #104, #202). Docs carry a prominent warning; v4 plans auto-re-arming.
+- A `Response` passed directly to `mockResponse` is served **as-is**: read-once body, same instance every call. Documented; don't "fix" without a major.
+- The once-gate and once-response of `dontMockOnceIf`/`doMockOnceIf` are consumed by the **same** fetch call — a call that evaluates unmocked still consumes a queued once-response silently.
+- `fetch()` must **never throw synchronously**: aborted signals and unparseable input surface as rejections (`AbortError` DOMException / TypeError) — fixed in 3.2.0 (#237); the try/catch in `normalizeResponse` is what guarantees it.
+- The `__isFallback` branch in `responseWrapper` exists for the whatwg-fetch browser polyfill; under node-fetch, `Response.body` is getter-only so its body assignments silently no-op. Near-dead under Jest; candidate for removal in v4.
+- The library calls `jest.fn()` at import time — it cannot load where Jest globals don't exist (`globalSetup`, plain Node scripts).
+- The abort error message is `The operation was aborted. ` (node's DOMException wording), not "Aborted!".
+
+## State as of 2026-07-08 and roadmap
+
+- 3.2.0 shipped the 2020–2026 backlog (the 3.1.0 version number was deliberately skipped — a stale 2024 git tag exists for it). Publishing it resolved ~10 open issues (#231, #252, #249, #201, #206, #109, #220, #95, #94...).
+- Issue tracker: obsolete/stale issues to close are listed in the tracker sweep (#4, #85, #62, #130, #161, #177, #155, #224, #104). Big open themes: Node native fetch conflicts (#218 is the key issue — the global overwrite breaks unrelated tests), feature requests (#166 default headers is most-wanted, #242 TimeoutError).
+- **v4.0.0 roadmap** (breaking, beta-soaked, API-compatible where possible): use the environment's native fetch primitives instead of stomping globals (jsdom still has no fetch in 2026 — keep a ponyfill fallback there); accept an injected mock factory (`createFetchMock(jest)`-style, fixes `injectGlobals: false`); dual CJS+ESM with an `exports` map including a `./*` escape hatch; self-contained types that don't force `lib: ["dom"]` or `@types/jest`; drop `domexception`; floor Node ≥18 / Jest ≥28; auto-re-arm after `resetMocks: true`; `AbortSignal.timeout()` → `TimeoutError`; global default response headers. Borrow from vitest-fetch-mock v0.4 (MIT fork of this repo, zero-dep TS rewrite) — but stay dual-format, not ESM-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,22 @@
+# Integration fixtures
+
+Each directory under `fixtures/` is a self-contained consumer project representing a major real-world way this library is used. `run.sh` packs the library (`npm pack`) and installs the tarball into every fixture — the same artifact a user gets from the registry — then runs that fixture's tests.
+
+| Fixture | Replicates |
+|---|---|
+| `jsdom-js` | Plain JavaScript app tested under `jest-environment-jsdom` (the classic CRA-style setup) |
+| `react-jsdom` | React component fetching on mount, asserted with Testing Library — the single biggest consumer cohort |
+| `ts-strict` | TypeScript strict mode + ts-jest, type-checked with `skipLibCheck: false` under two tsconfigs: full `@types/node`, and `types: ["jest"]` with no node types at all |
+| `node-native` | `jest-environment-node` on a Node ≥18 host where native fetch exists before the mock loads |
+| `jest30` | Jest 30 (current major) with `@jest/globals`-style imports |
+| `e2e-passthrough` | A real local HTTP server: conditional mocking (`dontMockIf`/`doMockIf`) passing unmatched requests through to actual network sockets, and `disableMocks` restoring real fetch |
+
+Run locally:
+
+```
+bash integration/run.sh
+```
+
+CI runs this on every PR and push to master (see `.github/workflows/nodejs.yml`). These fixtures gate every release: nothing ships to npm unless all of them pass against the packed tarball.
+
+Fixtures intentionally have no lockfiles — they float on current ecosystem versions so drift breaks here, not in users' projects.

--- a/integration/fixtures/e2e-passthrough/package.json
+++ b/integration/fixtures/e2e-passthrough/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fixture-e2e-passthrough",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "setupFiles": ["./setupJest.js"]
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/integration/fixtures/e2e-passthrough/passthrough.test.js
+++ b/integration/fixtures/e2e-passthrough/passthrough.test.js
@@ -1,0 +1,67 @@
+const http = require('http')
+
+// True end-to-end: unmatched requests travel through the real fetch
+// implementation over actual sockets to this local server.
+let server
+let baseUrl
+
+beforeAll((done) => {
+  server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.end('REAL:' + req.url)
+  })
+  server.listen(0, '127.0.0.1', () => {
+    baseUrl = `http://127.0.0.1:${server.address().port}`
+    done()
+  })
+})
+
+afterAll((done) => {
+  server.close(done)
+})
+
+beforeEach(() => {
+  fetchMock.resetMocks()
+})
+
+test('dontMockIf lets matching requests hit the real server', async () => {
+  fetchMock.dontMockIf((req) => req.url.startsWith(baseUrl), 'mocked')
+  await expect(
+    fetch(`${baseUrl}/hello`).then((r) => r.text())
+  ).resolves.toBe('REAL:/hello')
+  await expect(
+    fetch('https://api.example.com/x').then((r) => r.text())
+  ).resolves.toBe('mocked')
+})
+
+test('doMockIf scopes mocking to one URL, everything else is real', async () => {
+  fetchMock.doMockIf('https://api.example.com/only', 'scoped-mock')
+  await expect(
+    fetch('https://api.example.com/only').then((r) => r.text())
+  ).resolves.toBe('scoped-mock')
+  await expect(
+    fetch(`${baseUrl}/other`).then((r) => r.text())
+  ).resolves.toBe('REAL:/other')
+})
+
+test('dontMockOnce passes exactly one request through', async () => {
+  fetchMock.mockResponse('mocked')
+  fetchMock.dontMockOnce()
+  await expect(
+    fetch(`${baseUrl}/once`).then((r) => r.text())
+  ).resolves.toBe('REAL:/once')
+  await expect(
+    fetch(`${baseUrl}/again`).then((r) => r.text())
+  ).resolves.toBe('mocked')
+})
+
+test('disableMocks restores fully real fetch', async () => {
+  fetchMock.disableMocks()
+  try {
+    await expect(
+      fetch(`${baseUrl}/direct`).then((r) => r.text())
+    ).resolves.toBe('REAL:/direct')
+  } finally {
+    fetchMock.enableMocks()
+  }
+})

--- a/integration/fixtures/e2e-passthrough/setupJest.js
+++ b/integration/fixtures/e2e-passthrough/setupJest.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks()

--- a/integration/fixtures/jest30/api.test.js
+++ b/integration/fixtures/jest30/api.test.js
@@ -1,0 +1,27 @@
+const { describe, it, expect, beforeEach } = require('@jest/globals')
+
+describe('jest 30 consumer', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  it('mocks fetch under jest 30', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ jest: 30 }))
+    const res = await fetch('https://example.com/api')
+    expect(await res.json()).toEqual({ jest: 30 })
+  })
+
+  it('once-queue works', async () => {
+    fetchMock.once('a').once('b')
+    expect(await (await fetch('https://a.test')).text()).toBe('a')
+    expect(await (await fetch('https://b.test')).text()).toBe('b')
+  })
+
+  it('rejects on an already-aborted signal', async () => {
+    const c = new AbortController()
+    c.abort()
+    await expect(
+      fetch('https://example.com', { signal: c.signal })
+    ).rejects.toThrow()
+  })
+})

--- a/integration/fixtures/jest30/package.json
+++ b/integration/fixtures/jest30/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fixture-jest30",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "setupFiles": ["./setupJest.js"]
+  },
+  "devDependencies": {
+    "jest": "^30.0.0"
+  }
+}

--- a/integration/fixtures/jest30/setupJest.js
+++ b/integration/fixtures/jest30/setupJest.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks()

--- a/integration/fixtures/jsdom-js/api.test.js
+++ b/integration/fixtures/jsdom-js/api.test.js
@@ -1,0 +1,43 @@
+describe('jsdom consumer', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('mocks a JSON response', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
+    const res = await fetch('https://example.com/api')
+    expect(await res.json()).toEqual({ ok: true })
+    expect(fetchMock.mock.calls[0][0]).toBe('https://example.com/api')
+  })
+
+  it('accepts a Response object', async () => {
+    fetchMock.mockResponseOnce(new Response('raw body'))
+    const res = await fetch('https://example.com')
+    expect(await res.text()).toBe('raw body')
+  })
+
+  it('rejects on an already-aborted signal', async () => {
+    const c = new AbortController()
+    c.abort()
+    await expect(
+      fetch('https://example.com', { signal: c.signal })
+    ).rejects.toThrow()
+  })
+
+  it('supports conditional mocking', async () => {
+    fetchMock.doMockIf(/example\.com/, 'mocked')
+    const res = await fetch('https://example.com/x')
+    expect(await res.text()).toBe('mocked')
+  })
+
+  it('mocks rejections', async () => {
+    fetchMock.mockRejectOnce(new Error('boom'))
+    await expect(fetch('https://example.com')).rejects.toThrow('boom')
+  })
+
+  it('chains once()', async () => {
+    fetchMock.once('first').once('second')
+    expect(await (await fetch('https://a.test')).text()).toBe('first')
+    expect(await (await fetch('https://b.test')).text()).toBe('second')
+  })
+})

--- a/integration/fixtures/jsdom-js/package.json
+++ b/integration/fixtures/jsdom-js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fixture-jsdom-js",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "resetMocks": false,
+    "setupFiles": ["./setupJest.js"]
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
+  }
+}

--- a/integration/fixtures/jsdom-js/setupJest.js
+++ b/integration/fixtures/jsdom-js/setupJest.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks()

--- a/integration/fixtures/node-native/api.test.js
+++ b/integration/fixtures/node-native/api.test.js
@@ -1,0 +1,40 @@
+describe('node environment consumer (native fetch host)', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  it('mocks fetch in the node env', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ env: 'node' }))
+    const res = await fetch('https://example.com/api')
+    expect(await res.json()).toEqual({ env: 'node' })
+  })
+
+  it('mockAbort works (DOMException present)', async () => {
+    fetchMock.mockAbortOnce()
+    await expect(fetch('https://example.com')).rejects.toThrow(
+      'The operation was aborted'
+    )
+  })
+
+  it('rejects on an already-aborted signal', async () => {
+    const c = new AbortController()
+    c.abort()
+    await expect(
+      fetch('https://example.com', { signal: c.signal })
+    ).rejects.toThrow()
+  })
+
+  it('accepts a Response object with a Buffer body', async () => {
+    fetchMock.mockResponseOnce(new Response(Buffer.from('binary')))
+    const buf = await (await fetch('https://example.com')).arrayBuffer()
+    expect(Buffer.from(buf).toString('utf8')).toBe('binary')
+  })
+
+  it('disableMocks leaves a callable non-mock fetch', () => {
+    fetchMock.disableMocks()
+    expect(typeof fetch).toBe('function')
+    expect(jest.isMockFunction(fetch)).toBe(false)
+    fetchMock.enableMocks()
+    expect(jest.isMockFunction(fetch)).toBe(true)
+  })
+})

--- a/integration/fixtures/node-native/package.json
+++ b/integration/fixtures/node-native/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fixture-node-native",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "setupFiles": ["./setupJest.js"]
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/integration/fixtures/node-native/setupJest.js
+++ b/integration/fixtures/node-native/setupJest.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks()

--- a/integration/fixtures/react-jsdom/UserCard.js
+++ b/integration/fixtures/react-jsdom/UserCard.js
@@ -1,0 +1,32 @@
+const React = require('react')
+
+// Fetch-on-mount component, written without JSX so the fixture needs no babel.
+function UserCard() {
+  const [state, setState] = React.useState({ status: 'loading' })
+
+  React.useEffect(() => {
+    let alive = true
+    fetch('https://api.example.com/user')
+      .then((res) => {
+        if (!res.ok) throw new Error('HTTP ' + res.status)
+        return res.json()
+      })
+      .then((user) => alive && setState({ status: 'done', user }))
+      .catch(
+        (err) => alive && setState({ status: 'error', message: err.message })
+      )
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  if (state.status === 'loading') {
+    return React.createElement('p', null, 'Loading…')
+  }
+  if (state.status === 'error') {
+    return React.createElement('p', null, 'Error: ' + state.message)
+  }
+  return React.createElement('h1', null, state.user.name)
+}
+
+module.exports = UserCard

--- a/integration/fixtures/react-jsdom/UserCard.test.js
+++ b/integration/fixtures/react-jsdom/UserCard.test.js
@@ -1,0 +1,28 @@
+const React = require('react')
+const { render, screen } = require('@testing-library/react')
+const UserCard = require('./UserCard')
+
+beforeEach(() => {
+  fetchMock.resetMocks()
+})
+
+test('renders the fetched user', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ name: 'Ada Lovelace' }), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+  render(React.createElement(UserCard))
+  expect(await screen.findByText('Ada Lovelace')).toBeTruthy()
+  expect(fetchMock).toHaveBeenCalledWith('https://api.example.com/user')
+})
+
+test('renders the error state on a 500', async () => {
+  fetchMock.mockResponseOnce('oops', { status: 500 })
+  render(React.createElement(UserCard))
+  expect(await screen.findByText('Error: HTTP 500')).toBeTruthy()
+})
+
+test('renders the error state on a network failure', async () => {
+  fetchMock.mockRejectOnce(new Error('offline'))
+  render(React.createElement(UserCard))
+  expect(await screen.findByText('Error: offline')).toBeTruthy()
+})

--- a/integration/fixtures/react-jsdom/package.json
+++ b/integration/fixtures/react-jsdom/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "fixture-react-jsdom",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "resetMocks": false,
+    "setupFiles": ["./setupJest.js"]
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.3.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  }
+}

--- a/integration/fixtures/react-jsdom/setupJest.js
+++ b/integration/fixtures/react-jsdom/setupJest.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks()

--- a/integration/fixtures/ts-strict/api.test.ts
+++ b/integration/fixtures/ts-strict/api.test.ts
@@ -1,0 +1,50 @@
+import fetchMockDefault, {
+  enableFetchMocks,
+  FetchMock,
+  MockResponseInit,
+} from 'jest-fetch-mock';
+
+enableFetchMocks();
+
+describe('TypeScript strict consumer', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  it('global fetchMock is typed', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ n: 1 }));
+    const res = await fetch('https://example.com');
+    const data: { n: number } = await res.json();
+    expect(data.n).toBe(1);
+  });
+
+  it('function mocks are typed', async () => {
+    fetchMock.mockResponseOnce(
+      async (req: Request): Promise<MockResponseInit> => ({
+        body: `ok:${req.url}`,
+        status: 201,
+      })
+    );
+    const res = await fetch('https://example.com/');
+    expect(res.status).toBe(201);
+    expect(await res.text()).toBe('ok:https://example.com/');
+  });
+
+  it('Response overload compiles and runs', async () => {
+    fetchMock.mockResponseOnce(new Response('hi'));
+    expect(await (await fetch('https://x.test')).text()).toBe('hi');
+  });
+
+  it('default export is the same mock', () => {
+    const fm: FetchMock = fetchMockDefault;
+    expect(fm).toBe(fetchMock);
+  });
+
+  it('rejects on an already-aborted signal', async () => {
+    const c = new AbortController();
+    c.abort();
+    await expect(
+      fetch('https://example.com', { signal: c.signal })
+    ).rejects.toThrow();
+  });
+});

--- a/integration/fixtures/ts-strict/package.json
+++ b/integration/fixtures/ts-strict/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "fixture-ts-strict",
+  "private": true,
+  "scripts": {
+    "test": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.nonode.json && jest"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "setupFiles": ["./setupJest.js"]
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^22.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/integration/fixtures/ts-strict/setupJest.js
+++ b/integration/fixtures/ts-strict/setupJest.js
@@ -1,0 +1,1 @@
+require('jest-fetch-mock').enableMocks()

--- a/integration/fixtures/ts-strict/tsconfig.json
+++ b/integration/fixtures/ts-strict/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2019",
+    "module": "commonjs",
+    "lib": ["es2019"],
+    "esModuleInterop": true,
+    "skipLibCheck": false,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/integration/fixtures/ts-strict/tsconfig.nonode.json
+++ b/integration/fixtures/ts-strict/tsconfig.nonode.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2019",
+    "module": "commonjs",
+    "lib": ["es2019"],
+    "esModuleInterop": true,
+    "skipLibCheck": false,
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["*.ts"]
+}

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Packs the library and runs every fixture in integration/fixtures against
+# the packed tarball - exactly what a consumer installing from npm gets.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+TARBALL_NAME=$(npm pack --silent)
+TARBALL="$PWD/$TARBALL_NAME"
+trap 'rm -f "$TARBALL"' EXIT
+
+for fixture in integration/fixtures/*/; do
+  name=$(basename "$fixture")
+  echo ""
+  echo "=== integration: $name ==="
+  (
+    cd "$fixture"
+    rm -rf node_modules
+    npm install --no-audit --no-fund --loglevel=error
+    npm install --no-save --no-audit --no-fund --loglevel=error "$TARBALL"
+    npm test
+  )
+done
+
+echo ""
+echo "All integration fixtures passed."

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "homepage": "https://github.com/jefflau/jest-fetch-mock#readme",
   "dependencies": {
     "cross-fetch": "^3.1.8",
-    "domexception": "^4.0.0",
-    "promise-polyfill": "^8.3.0"
+    "domexception": "^4.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
@@ -78,10 +77,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 93,
-        "branches": 85,
-        "functions": 95,
-        "lines": 93
+        "statements": 98,
+        "branches": 96,
+        "functions": 100,
+        "lines": 98
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   "jest": {
     "automock": false,
     "testPathIgnorePatterns": [
-      "types"
+      "types",
+      "integration"
     ],
     "setupFiles": [
       "./setupJest.js"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,21 @@
     ],
     "setupFiles": [
       "./setupJest.js"
-    ]
+    ],
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.js"
+    ],
+    "coverageReporters": [
+      "text-summary"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 93,
+        "branches": 85,
+        "functions": 95,
+        "lines": 93
+      }
+    }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -125,13 +125,9 @@ const normalizeResponse = (bodyOrFunction, init) => (input, reqInit) => {
             ? responseWrapper(resp, init)
             : responseWrapper(resp.body, responseInit(resp, init))
         })
-      : new Promise((resolve, reject) => {
-          if (request.signal && request.signal.aborted) {
-            reject(abortError())
-            return
-          }
-          resolve(responseWrapper(bodyOrFunction, init))
-        })
+      : // an aborted signal has already rejected in the isMocking call above,
+        // so the static body can resolve unconditionally
+        Promise.resolve(responseWrapper(bodyOrFunction, init))
     : crossFetch.fetch(input, reqInit)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,6 @@ global.Response = crossFetch.Response
 global.Headers = crossFetch.Headers
 global.Request = crossFetch.Request
 
-if (typeof Promise === 'undefined') {
-  Promise = require('promise-polyfill')
-} else if (!('finally' in Promise) || typeof Promise.finally === 'undefined') {
-  Promise.finally = require('promise-polyfill').finally
-}
-
 if (typeof DOMException === 'undefined') {
   DOMException = require('domexception')
 }
@@ -73,9 +67,9 @@ function requestMatches(urlOrPredicate) {
 
 function requestNotMatches(urlOrPredicate) {
   const matches = requestMatches(urlOrPredicate)
-  return (input) => {
-    const result = matches(input)
-    return [!result[0], result[1]]
+  return (input, reqInit) => {
+    const [matched, request] = matches(input, reqInit)
+    return [!matched, request]
   }
 }
 
@@ -137,19 +131,20 @@ const normalizeRequest = (input, reqInit) => {
       abort()
     }
     return input
-  } else if (typeof input === 'string') {
-    if (reqInit && reqInit.signal && reqInit.signal.aborted) {
-      abort()
-    }
-    return new Request(input, reqInit)
-  } else if (typeof input.toString === 'function') {
-    if (reqInit && reqInit.signal && reqInit.signal.aborted) {
-      abort()
-    }
-    return new Request(input.toString(), reqInit)
-  } else {
+  }
+  const url =
+    typeof input === 'string'
+      ? input
+      : input != null && typeof input.toString === 'function'
+      ? input.toString()
+      : null
+  if (url === null) {
     throw new TypeError('Unable to parse input as string or Request')
   }
+  if (reqInit && reqInit.signal && reqInit.signal.aborted) {
+    abort()
+  }
+  return new Request(url, reqInit)
 }
 
 const normalizeError = (errorOrFunction) =>
@@ -194,67 +189,39 @@ fetch.mockResponses = (...responses) => {
 
 fetch.isMocking = (req, reqInit) => isMocking(req, reqInit)[0]
 
-fetch.mockIf = fetch.doMockIf = (urlOrPredicate, bodyOrFunction, init) => {
-  isMocking.mockImplementation(requestMatches(urlOrPredicate))
+// every conditional mock is the same operation: install a matcher on
+// isMocking (persistently or for one call) and optionally set a response
+// with the same persistence
+const configureMocking = (once, matcher, bodyOrFunction, init) => {
+  isMocking[once ? 'mockImplementationOnce' : 'mockImplementation'](matcher)
   if (bodyOrFunction) {
-    fetch.mockResponse(bodyOrFunction, init)
+    const respond = once ? mockResponseOnce : fetch.mockResponse
+    respond(bodyOrFunction, init)
   }
   return fetch
 }
 
-fetch.dontMockIf = (urlOrPredicate, bodyOrFunction, init) => {
-  isMocking.mockImplementation(requestNotMatches(urlOrPredicate))
-  if (bodyOrFunction) {
-    fetch.mockResponse(bodyOrFunction, init)
-  }
-  return fetch
-}
+fetch.mockIf = fetch.doMockIf = (urlOrPredicate, body, init) =>
+  configureMocking(false, requestMatches(urlOrPredicate), body, init)
 
-fetch.mockOnceIf = fetch.doMockOnceIf = (
-  urlOrPredicate,
-  bodyOrFunction,
-  init
-) => {
-  isMocking.mockImplementationOnce(requestMatches(urlOrPredicate))
-  if (bodyOrFunction) {
-    mockResponseOnce(bodyOrFunction, init)
-  }
-  return fetch
-}
+fetch.dontMockIf = (urlOrPredicate, body, init) =>
+  configureMocking(false, requestNotMatches(urlOrPredicate), body, init)
 
-fetch.dontMockOnceIf = (urlOrPredicate, bodyOrFunction, init) => {
-  isMocking.mockImplementationOnce(requestNotMatches(urlOrPredicate))
-  if (bodyOrFunction) {
-    mockResponseOnce(bodyOrFunction, init)
-  }
-  return fetch
-}
+fetch.mockOnceIf = fetch.doMockOnceIf = (urlOrPredicate, body, init) =>
+  configureMocking(true, requestMatches(urlOrPredicate), body, init)
 
-fetch.dontMock = () => {
-  isMocking.mockImplementation(staticMatches(false))
-  return fetch
-}
+fetch.dontMockOnceIf = (urlOrPredicate, body, init) =>
+  configureMocking(true, requestNotMatches(urlOrPredicate), body, init)
 
-fetch.dontMockOnce = () => {
-  isMocking.mockImplementationOnce(staticMatches(false))
-  return fetch
-}
+fetch.doMock = (body, init) =>
+  configureMocking(false, staticMatches(true), body, init)
 
-fetch.doMock = (bodyOrFunction, init) => {
-  isMocking.mockImplementation(staticMatches(true))
-  if (bodyOrFunction) {
-    fetch.mockResponse(bodyOrFunction, init)
-  }
-  return fetch
-}
+fetch.mockOnce = fetch.doMockOnce = (body, init) =>
+  configureMocking(true, staticMatches(true), body, init)
 
-fetch.mockOnce = fetch.doMockOnce = (bodyOrFunction, init) => {
-  isMocking.mockImplementationOnce(staticMatches(true))
-  if (bodyOrFunction) {
-    mockResponseOnce(bodyOrFunction, init)
-  }
-  return fetch
-}
+fetch.dontMock = () => configureMocking(false, staticMatches(false))
+
+fetch.dontMockOnce = () => configureMocking(true, staticMatches(false))
 
 fetch.resetMocks = () => {
   fetch.mockReset()
@@ -263,7 +230,6 @@ fetch.resetMocks = () => {
   // reset to default implementation with each reset
   fetch.mockImplementation(normalizeResponse(''))
   fetch.doMock()
-  fetch.isMocking = (req, reqInit) => isMocking(req, reqInit)[0]
 }
 
 fetch.enableMocks = fetch.enableFetchMocks = () => {

--- a/tests/node.test.js
+++ b/tests/node.test.js
@@ -7,5 +7,5 @@ if (typeof DOMException === 'undefined') {
 
 it('rejects with a dom exception', () => {
   fetch.mockAbort()
-  expect(fetch('/')).rejects.toThrow(expect.any(DOMException))
+  return expect(fetch('/')).rejects.toThrow(expect.any(DOMException))
 })

--- a/tests/surface.test.js
+++ b/tests/surface.test.js
@@ -1,0 +1,314 @@
+describe('Response passthrough', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('preserves status and headers of a directly passed Response', async () => {
+    fetch.mockResponseOnce(
+      new Response('teapot', { status: 418, headers: { 'x-tea': 'chai' } })
+    )
+    const response = await fetch('https://tea.test')
+    expect(response.status).toBe(418)
+    expect(response.headers.get('x-tea')).toBe('chai')
+    await expect(response.text()).resolves.toBe('teapot')
+  })
+
+  it('preserves status and headers of a Response returned from a function', async () => {
+    fetch.mockResponseOnce(
+      async () =>
+        new Response('made in fn', {
+          status: 202,
+          headers: { 'x-from': 'function' },
+        })
+    )
+    const response = await fetch('https://fn.test')
+    expect(response.status).toBe(202)
+    expect(response.headers.get('x-from')).toBe('function')
+    await expect(response.text()).resolves.toBe('made in fn')
+  })
+
+  it('preserves status of a Response returned from a synchronous function', async () => {
+    fetch.mockResponseOnce(() => new Response('sync response', { status: 203 }))
+    const response = await fetch('https://sync.test')
+    expect(response.status).toBe(203)
+    await expect(response.text()).resolves.toBe('sync response')
+  })
+
+  it('returns the same instance for repeated calls with mockResponse', async () => {
+    const response = new Response('once-only')
+    fetch.mockResponse(response)
+    const first = await fetch('https://a.test')
+    await expect(first.text()).resolves.toBe('once-only')
+    const second = await fetch('https://b.test')
+    expect(second).toBe(first)
+    expect(second.bodyUsed).toBe(true)
+  })
+
+  it('wraps whatwg-fetch fallback stream bodies and tees them on clone', async () => {
+    // Simulates the whatwg-fetch polyfill's stream body (constructor.__isFallback).
+    // Under node-fetch, Response.body is getter-only so the body reassignment is
+    // only observable in browser-polyfill environments; here we assert the
+    // wrapping mechanism: init is applied and clone() tees the fallback stream.
+    function FallbackBody(parts) {
+      this.parts = parts
+    }
+    FallbackBody.__isFallback = true
+    const makeBody = (parts) => {
+      const body = new FallbackBody(parts)
+      body.tee = jest.fn(() => [makeBody(parts), makeBody(parts)])
+      return body
+    }
+    const body = makeBody(['a'])
+    fetch.mockResponseOnce(body, { status: 201 })
+    const response = await fetch('https://fallback.test')
+    expect(response.status).toBe(201)
+    expect(typeof response.clone).toBe('function')
+    const clone = response.clone()
+    expect(body.tee).toHaveBeenCalledTimes(1)
+    expect(clone).toBeInstanceOf(Response)
+  })
+})
+
+describe('input handling', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('rejects with a TypeError for unparseable input', () => {
+    return expect(fetch(Object.create(null))).rejects.toThrow(TypeError)
+  })
+
+  it('rejects for an aborted signal with stringifier input', () => {
+    const c = new AbortController()
+    c.abort()
+    const stringifier = { toString: () => 'https://bing.test' }
+    return expect(
+      fetch(stringifier, { signal: c.signal })
+    ).rejects.toThrow('The operation was aborted')
+  })
+
+  it('rejects for an aborted signal on a Request instance', () => {
+    const c = new AbortController()
+    c.abort()
+    const request = new Request('https://req.test', { signal: c.signal })
+    return expect(fetch(request)).rejects.toThrow(
+      'The operation was aborted'
+    )
+  })
+
+  it('accepts a Request instance as input', async () => {
+    fetch.mockResponseOnce('from request')
+    const response = await fetch(new Request('https://req.test'))
+    await expect(response.text()).resolves.toBe('from request')
+    expect(fetch.mock.calls[0][0]).toBeInstanceOf(Request)
+  })
+})
+
+describe('reject and abort persistence', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('mockReject persists across calls', async () => {
+    fetch.mockReject(new Error('always down'))
+    await expect(fetch('https://a.test')).rejects.toThrow('always down')
+    await expect(fetch('https://b.test')).rejects.toThrow('always down')
+  })
+
+  it('mockAbort persists across calls', async () => {
+    fetch.mockAbort()
+    await expect(fetch('https://a.test')).rejects.toThrow(
+      'The operation was aborted'
+    )
+    await expect(fetch('https://b.test')).rejects.toThrow(
+      'The operation was aborted'
+    )
+  })
+
+  it('mockAbortOnce aborts only the next call', async () => {
+    fetch.mockAbortOnce()
+    await expect(fetch('https://a.test')).rejects.toThrow(
+      'The operation was aborted'
+    )
+    const response = await fetch('https://b.test')
+    await expect(response.text()).resolves.toBe('')
+  })
+})
+
+describe('reset state machine', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('isMocking returns booleans before and after resetMocks', () => {
+    expect(fetch.isMocking('https://a.test')).toBe(true)
+    fetch.dontMock()
+    expect(fetch.isMocking('https://a.test')).toBe(false)
+    fetch.resetMocks()
+    expect(fetch.isMocking('https://a.test')).toBe(true)
+  })
+
+  it('resetMocks restores the default empty-string implementation', async () => {
+    fetch.mockResponse('data')
+    fetch.resetMocks()
+    const response = await fetch('https://a.test')
+    await expect(response.text()).resolves.toBe('')
+  })
+})
+
+describe('mockResponses variants', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('accepts strings, tuples, Responses and functions', async () => {
+    fetch.mockResponses(
+      'plain',
+      ['tuple', { status: 201 }],
+      new Response('direct'),
+      () => 'fn'
+    )
+    await expect(fetch('https://1.test').then((r) => r.text())).resolves.toBe(
+      'plain'
+    )
+    const second = await fetch('https://2.test')
+    expect(second.status).toBe(201)
+    await expect(second.text()).resolves.toBe('tuple')
+    await expect(fetch('https://3.test').then((r) => r.text())).resolves.toBe(
+      'direct'
+    )
+    await expect(fetch('https://4.test').then((r) => r.text())).resolves.toBe(
+      'fn'
+    )
+  })
+
+  it('mocks a redirected response via counter', async () => {
+    fetch.mockResponseOnce('<main></main>', { counter: 1, status: 200 })
+    const response = await fetch('https://redirect.test')
+    expect(response.redirected).toBe(true)
+
+    fetch.mockResponseOnce('<main></main>', { status: 200 })
+    const plain = await fetch('https://plain.test')
+    expect(plain.redirected).toBe(false)
+  })
+})
+
+describe('conditional mocking without bodies', () => {
+  const realResponse = 'REAL FETCH RESPONSE'
+  let crossFetchSpy
+
+  beforeEach(() => {
+    fetch.resetMocks()
+    fetch.mockResponse('gated')
+    crossFetchSpy = jest
+      .spyOn(require('cross-fetch'), 'fetch')
+      .mockImplementation(async () => new Response(realResponse))
+  })
+
+  afterEach(() => {
+    crossFetchSpy.mockRestore()
+  })
+
+  const text = (uri) => fetch(uri, {}).then((r) => r.text())
+
+  it('doMockIf without a body gates the existing mock by url', async () => {
+    fetch.doMockIf('https://yes.test/')
+    await expect(text('https://yes.test/')).resolves.toBe('gated')
+    await expect(text('https://no.test/')).resolves.toBe(realResponse)
+  })
+
+  it('doMockOnceIf without a body gates only the next call', async () => {
+    fetch.dontMock()
+    fetch.doMockOnceIf('https://yes.test/')
+    await expect(text('https://yes.test/')).resolves.toBe('gated')
+    await expect(text('https://yes.test/')).resolves.toBe(realResponse)
+  })
+
+  it('dontMockIf without a body inverts the gate', async () => {
+    fetch.dontMockIf('https://no.test/')
+    await expect(text('https://no.test/')).resolves.toBe(realResponse)
+    await expect(text('https://yes.test/')).resolves.toBe('gated')
+  })
+
+  it('dontMockOnceIf without a body skips mocking only once', async () => {
+    fetch.dontMockOnceIf('https://no.test/')
+    await expect(text('https://no.test/')).resolves.toBe(realResponse)
+    await expect(text('https://no.test/')).resolves.toBe('gated')
+  })
+
+  it('doMockOnce without a body mocks the next call with the default', async () => {
+    fetch.dontMock()
+    fetch.doMockOnce()
+    await expect(text('https://any.test/')).resolves.toBe('gated')
+    await expect(text('https://any.test/')).resolves.toBe(realResponse)
+  })
+
+  it('mockIf with a body sets the response in the same call', async () => {
+    fetch.mockIf('https://yes.test/', 'if-body')
+    await expect(text('https://yes.test/')).resolves.toBe('if-body')
+    await expect(text('https://no.test/')).resolves.toBe(realResponse)
+  })
+
+  it('dontMockIf with a body sets the response in the same call', async () => {
+    fetch.dontMockIf('https://no.test/', 'dont-if-body')
+    await expect(text('https://yes.test/')).resolves.toBe('dont-if-body')
+    await expect(text('https://no.test/')).resolves.toBe(realResponse)
+  })
+
+  it('mockOnceIf with a body sets the response for one call', async () => {
+    fetch.mockOnceIf('https://yes.test/', 'once-if-body')
+    await expect(text('https://yes.test/')).resolves.toBe('once-if-body')
+    await expect(text('https://yes.test/')).resolves.toBe('gated')
+  })
+
+  it('dontMockOnceIf with a body serves that body to non-matching calls', async () => {
+    // the once-gate and once-response are consumed by the same fetch call:
+    // a matching (unmocked) call consumes the queued body without serving it
+    fetch.dontMockOnceIf('https://no.test/', 'dont-once-body')
+    await expect(text('https://yes.test/')).resolves.toBe('dont-once-body')
+    await expect(text('https://yes.test/')).resolves.toBe('gated')
+  })
+
+  it('doMock with a body resets the default response', async () => {
+    fetch.dontMock()
+    fetch.doMock('do-mock-body')
+    await expect(text('https://any.test/')).resolves.toBe('do-mock-body')
+  })
+
+  it('mockOnce with a body mocks exactly one call', async () => {
+    fetch.dontMock()
+    fetch.mockOnce('once-body')
+    await expect(text('https://any.test/')).resolves.toBe('once-body')
+    await expect(text('https://any.test/')).resolves.toBe(realResponse)
+  })
+})
+
+describe('exposed API', () => {
+  beforeEach(() => {
+    fetch.resetMocks()
+  })
+
+  it('exposes Headers, Request and a Response factory', () => {
+    expect(fetch.Headers).toBe(Headers)
+    expect(fetch.Request).toBe(Request)
+    expect(typeof fetch.Response).toBe('function')
+    expect(fetch.Response('x')).toBeInstanceOf(Response)
+  })
+
+  it('module default export is the mock itself', () => {
+    const mod = require('jest-fetch-mock')
+    expect(mod.default).toBe(mod)
+    expect(jest.isMockFunction(mod)).toBe(true)
+  })
+
+  it('supports synchronous response functions', async () => {
+    fetch.mockResponseOnce(() => 'sync')
+    const response = await fetch('https://s.test')
+    await expect(response.text()).resolves.toBe('sync')
+  })
+
+  it('once without arguments mocks the next call with the default response', async () => {
+    const response = await fetch('https://default.test')
+    await expect(response.text()).resolves.toBe('')
+  })
+})

--- a/tests/surface.test.js
+++ b/tests/surface.test.js
@@ -281,6 +281,14 @@ describe('conditional mocking without bodies', () => {
     await expect(text('https://any.test/')).resolves.toBe('once-body')
     await expect(text('https://any.test/')).resolves.toBe(realResponse)
   })
+
+  it('dontMockIf predicates receive the request init', async () => {
+    fetch.dontMockIf((req) => req.method === 'POST')
+    await expect(
+      fetch('https://any.test/', { method: 'POST' }).then((r) => r.text())
+    ).resolves.toBe(realResponse)
+    await expect(text('https://any.test/')).resolves.toBe('gated')
+  })
 })
 
 describe('exposed API', () => {

--- a/tests/test.js
+++ b/tests/test.js
@@ -42,9 +42,7 @@ describe('testing mockResponse and alias once', () => {
   })
 
   it('mocks a response with alias .once', async () => {
-    fetch.mockResponseOnce(
-      JSON.stringify({ secret_data: 'abcde' }, { status: 200 })
-    )
+    fetch.once(JSON.stringify({ secret_data: 'abcde' }, { status: 200 }))
 
     const response = await APIRequest('google')
 
@@ -90,11 +88,11 @@ describe('testing mockResponse and alias once', () => {
       JSON.stringify({ secret_data: 'abcde' }, { status: 200 })
     )
 
-    const response = await APIRequest('instagram')
+    const response = await APIRequest('bing')
 
     expect(response).toEqual({ secret_data: 'abcde' })
     expect(fetch.mock.calls.length).toEqual(1)
-    expect(fetch.mock.calls[0][0]).toEqual(new URL('https://instagram.com'))
+    expect(fetch.mock.calls[0][0].toString()).toEqual('https://bing.com')
   });
 })
 
@@ -133,7 +131,7 @@ describe('Mocking aborts', () => {
 
   it('rejects with a dom exception', () => {
     fetch.mockAbort()
-    expect(fetch('/')).rejects.toThrow(expect.any(DOMException))
+    return expect(fetch('/')).rejects.toThrow(expect.any(DOMException))
   })
   it('rejects once then mocks with empty response', async () => {
     fetch.mockAbortOnce()
@@ -242,13 +240,8 @@ describe('request', () => {
       },
     })
 
-    try {
-      const response = await request()
-      expect(response.type).toBe(contentType)
-    } catch (e) {
-      console.log(e)
-    }
-
+    const response = await request()
+    expect(response.type).toBe(contentType)
     expect(fetch).toHaveBeenCalledWith('https://randomuser.me/api', {})
   })
 
@@ -307,14 +300,9 @@ describe('request', () => {
       () =>
         new Promise((_, reject) =>
           setTimeout(() => reject(JSON.stringify(errorData)))
-        ),
-      100
+        )
     )
-    try {
-      await request()
-    } catch (error) {
-      expect(error.message).toBe(errorData.error)
-    }
+    await expect(request()).rejects.toThrow(errorData.error)
   })
 
   it('resolves with function returning object body and init headers', async () => {
@@ -771,6 +759,4 @@ it('enable/disable', () => {
   expect(jest.isMockFunction(fetch)).toBe(false)
   jestFetchMock.enableMocks()
   expect(jest.isMockFunction(fetch)).toBe(true)
-  jestFetchMock.disableMocks()
-  global.fetch = jestFetchMock
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
         "./"
       ]
     }
-  }
+  },
+  "exclude": ["node_modules", "integration"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2435,11 +2435,6 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-promise-polyfill@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
-  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
-
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"


### PR DESCRIPTION
The pre-release quality push:

- **Test hygiene + expansion**: fixed vacuous/copy-paste tests in the existing suite, added `tests/surface.test.js` covering the whole API surface. 64 → 98 tests; coverage 83% → 99.3% statements / 98.4% branches, now **enforced with thresholds on every run**.
- **Integration suite** (`integration/`): six consumer fixtures run against the packed tarball on every PR — jsdom JS, React + Testing Library, TS strict (checked with and without @types/node), node-native-fetch host, Jest 30, and a real-local-HTTP-server e2e fixture proving conditional-mock passthrough over actual sockets.
- **Compression, no API changes**: the eight conditional-mock functions folded into one `configureMocking` helper, `normalizeRequest` flattened, dead `promise-polyfill` dependency removed (Node ≥12 floor makes it unreachable). One latent bug fixed along the way: `dontMockIf` predicates now receive request init (method/headers), matching `doMockIf`.
- **AGENTS.md/CLAUDE.md**: maintainer + agent working knowledge (architecture, release process and gates, conventions, behavioral subtleties, v4 roadmap).