### PR TITLE
4.1.0: Response statics + README alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 4.1.0 (2026-07-08)
+
+### Added
+
+- `fetchMock.Response.redirect()`, `.error()` and (on native fetch) `.json()` statics are exposed through the Response wrapper ([#191])
+
+### Docs
+
+- README fully aligned with 4.0 (native-primitives intro, `setupFilesAfterEnv` one-liner as the primary setup, rewritten `resetMocks` note around the auto-re-arm, self-contained types, redirected mocking works everywhere, `realFetch` in examples)
+
+[#191]: https://github.com/jefflau/jest-fetch-mock/issues/191
+
 ## 4.0.0 (2026-07-08)
 
 The modernization release (published as `4.0.0-beta.1` earlier the same day; identical content). Headline: **jest-fetch-mock no longer replaces the global fetch classes with node-fetch implementations.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-fetch-mock",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "fetch mock for jest",
   "main": "src/index.js",
   "types": "./types/index.d.ts",

--- a/src/createFetchMock.js
+++ b/src/createFetchMock.js
@@ -223,6 +223,14 @@ function createFetchMock(jestLike) {
   fetch.Headers = primitives.Headers
   fetch.Response = responseWrapper
   fetch.Request = ActualRequest
+  // expose the backing class's statics through the wrapper; json only
+  // exists on native Response, not node-fetch 2 (#191)
+  for (const staticMethod of ['error', 'redirect', 'json']) {
+    if (typeof ActualResponse[staticMethod] === 'function') {
+      responseWrapper[staticMethod] =
+        ActualResponse[staticMethod].bind(ActualResponse)
+    }
+  }
   // the implementation unmatched requests pass through to; reassignable in
   // tests that want to stub the real network
   fetch.realFetch = primitives.fetch

--- a/tests/v4.test.js
+++ b/tests/v4.test.js
@@ -98,6 +98,28 @@ describe('relative URLs in native mode', () => {
   })
 })
 
+describe('Response wrapper statics', () => {
+  it('exposes redirect and error from the backing class', () => {
+    const redirect = fetch.Response.redirect('https://elsewhere.test/', 301)
+    expect(redirect.status).toBe(301)
+    expect(redirect.headers.get('location')).toBe('https://elsewhere.test/')
+    const error = fetch.Response.error()
+    expect(error.type).toBe('error')
+  })
+
+  it('exposes the native json static where available', async () => {
+    const response = fetch.Response.json({ a: 1 })
+    await expect(response.json()).resolves.toEqual({ a: 1 })
+  })
+
+  it('redirect responses can be served as mocks', async () => {
+    fetch.mockResponseOnce(fetch.Response.redirect('https://moved.test/', 302))
+    const response = await fetch('https://old.test/')
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('https://moved.test/')
+  })
+})
+
 describe('createFetchMock factory', () => {
   it('builds an isolated instance from an injected jest object', async () => {
     const createFetchMock = require('jest-fetch-mock/factory')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -142,7 +142,13 @@ export interface FetchMock extends FetchMockInstance {
 
     Headers: typeof Headers;
     Request: typeof Request;
-    Response: (body?: unknown, init?: MockParams) => Response;
+    Response: {
+        (body?: unknown, init?: MockParams): Response;
+        redirect(url: string | URL, status?: number): Response;
+        error(): Response;
+        /** Present when the backing Response class provides it (native fetch; not node-fetch 2). */
+        json?(data: unknown, init?: ResponseInit): Response;
+    };
 }
 
 export interface MockParams {

--- a/types/test.ts
+++ b/types/test.ts
@@ -13,6 +13,9 @@ fm3.realFetch = passthrough;
 const isNative: boolean = fm3.usingNativeFetch;
 fm3.defaultResponseInit = { headers: { 'Content-Type': 'application/json' } };
 fm3.defaultResponseInit = undefined;
+fetchMock.Response.redirect('https://x.test/', 301);
+fetchMock.Response.error();
+fetchMock.Response.json?.({ a: 1 });
 
 fetchMock.mockResponse(JSON.stringify({foo: "bar"}));
 fetchMock.mockResponse(JSON.stringify({foo: "bar"}), {


### PR DESCRIPTION
- `fetchMock.Response.redirect()` / `.error()` / (native) `.json()` exposed through the wrapper — closes #191, the last easily-fixable open request
- Carries the README v4-alignment pass to the registry (the npm page still shows the pre-audit README from the 4.0.0 tarball)

Part of the final issue sweep: 33 of the 40 remaining open issues are being closed as resolved/answered/obsolete; #171 (mockIf stacking) stays open as the flagship 4.x feature request.